### PR TITLE
Renaming basic operations of the GeneralizedMass type

### DIFF
--- a/src/axion/constraints/contact_constraint.py
+++ b/src/axion/constraints/contact_constraint.py
@@ -1,7 +1,8 @@
 import warp as wp
-from axion.types import *
 from axion.types import ContactInteraction
 from axion.types import GeneralizedMass
+from axion.types import gm_add
+from axion.types import gm_mul
 
 from .utils import scaled_fisher_burmeister
 from .utils import scaled_fisher_burmeister_new
@@ -110,8 +111,8 @@ def contact_constraint_kernel(
     )
 
     # TODO: Fix this
-    Minv = gen_inv_mass[body_a_idx] + gen_inv_mass[body_b_idx]
-    r = wp.dot(J_n_a, Minv * J_n_a)
+    Minv = gm_add(gen_inv_mass[body_a_idx], gen_inv_mass[body_b_idx])
+    r = wp.dot(J_n_a, gm_mul(Minv, J_n_a))
 
     # Evaluate the Fisher-Burmeister complementarity function φ(a, λ)
     phi_n, dphi_da, dphi_dlambda = scaled_fisher_burmeister_new(constraint_term_a, lambda_normal, r)
@@ -202,8 +203,8 @@ def linesearch_contact_residuals_kernel(
     )
 
     # TODO: Check if this is correct
-    Minv = gen_inv_mass[body_a_idx] + gen_inv_mass[body_b_idx]
-    r = wp.dot(J_n_a, Minv * J_n_a)
+    Minv = gm_add(gen_inv_mass[body_a_idx], gen_inv_mass[body_b_idx])
+    r = wp.dot(J_n_a, gm_mul(Minv, J_n_a))
 
     # Evaluate the Fisher-Burmeister complementarity function φ(λ, b)
     phi_n, _, _ = scaled_fisher_burmeister_new(constraint_term_a, lambda_normal, r)

--- a/src/axion/constraints/dynamics_constraint.py
+++ b/src/axion/constraints/dynamics_constraint.py
@@ -1,6 +1,6 @@
 import warp as wp
-from axion.types import *
 from axion.types import GeneralizedMass
+from axion.types import gm_mul
 
 
 @wp.kernel
@@ -26,9 +26,9 @@ def unconstrained_dynamics_kernel(
     u_prev = body_qd_prev[body_idx]
     f = body_f[body_idx]
 
-    f_g = M * wp.spatial_vector(wp.vec3(), g_accel)
+    f_g = gm_mul(M, wp.spatial_vector(wp.vec3(), g_accel))
 
-    g[body_idx] = M * (u - u_prev) - (f + f_g) * dt
+    g[body_idx] = gm_mul(M, u - u_prev) - (f + f_g) * dt
 
 
 @wp.kernel
@@ -56,6 +56,6 @@ def linesearch_dynamics_residuals_kernel(
     u_prev = body_qd_prev[body_idx]
     f = body_f[body_idx]
 
-    f_g = M * wp.spatial_vector(wp.vec3(), g_accel)
+    f_g = gm_mul(M, wp.spatial_vector(wp.vec3(), g_accel))
 
-    g_alpha[alpha_idx, body_idx] = M * (u - u_prev) - (f + f_g) * dt
+    g_alpha[alpha_idx, body_idx] = gm_mul(M, u - u_prev) - (f + f_g) * dt

--- a/src/axion/core/dense_utils.py
+++ b/src/axion/core/dense_utils.py
@@ -1,5 +1,4 @@
 import warp as wp
-from axion.types import *
 from axion.types import GeneralizedMass
 
 from .engine_config import EngineConfig

--- a/src/axion/core/linear_utils.py
+++ b/src/axion/core/linear_utils.py
@@ -3,8 +3,8 @@ from axion.constraints import contact_constraint_kernel
 from axion.constraints import friction_constraint_kernel
 from axion.constraints import joint_constraint_kernel
 from axion.constraints import unconstrained_dynamics_kernel
-from axion.types import *
 from axion.types import GeneralizedMass
+from axion.types import gm_mul
 
 from .engine_config import EngineConfig
 from .engine_data import EngineArrays
@@ -29,8 +29,8 @@ def update_system_rhs_kernel(
     J_ib = J_values[constraint_idx, 1]
 
     # Calculate (J_i * H^-1 * g)
-    a_contrib = wp.dot(J_ia, Hinv[body_a] * g[body_a])
-    b_contrib = wp.dot(J_ib, Hinv[body_b] * g[body_b])
+    a_contrib = wp.dot(J_ia, gm_mul(Hinv[body_a], g[body_a]))
+    b_contrib = wp.dot(J_ib, gm_mul(Hinv[body_b], g[body_b]))
     JHinvg = a_contrib + b_contrib
 
     # b = J * H^-1 * g - h
@@ -73,7 +73,9 @@ def compute_delta_body_qd_kernel(
     if body_idx >= gen_inv_mass.shape[0]:
         return
 
-    delta_body_qd[body_idx] = gen_inv_mass[body_idx] * (JT_delta_lambda[body_idx] - g[body_idx])
+    delta_body_qd[body_idx] = gm_mul(
+        gen_inv_mass[body_idx], (JT_delta_lambda[body_idx] - g[body_idx])
+    )
 
 
 def compute_linear_system(

--- a/src/axion/optim/matrixfree_operator.py
+++ b/src/axion/optim/matrixfree_operator.py
@@ -16,8 +16,8 @@ Residual (CR) or Conjugate Gradient (CG), allowing the system to be solved
 without ever forming the potentially very large and dense matrix A explicitly.
 """
 import warp as wp
-from axion.types import *
 from axion.types import GeneralizedMass
+from axion.types import gm_mul
 from warp.optim.linear import LinearOperator
 
 
@@ -73,7 +73,7 @@ def kernel_inv_mass_matvec(
     """
     body_idx = wp.tid()
 
-    out_vec[body_idx] = gen_inv_mass[body_idx] * in_vec[body_idx]
+    out_vec[body_idx] = gm_mul(gen_inv_mass[body_idx], in_vec[body_idx])
 
 
 @wp.kernel

--- a/src/axion/optim/preconditioner.py
+++ b/src/axion/optim/preconditioner.py
@@ -1,6 +1,6 @@
 import warp as wp
-from axion.types import *
 from axion.types import GeneralizedMass
+from axion.types import gm_mul
 from warp.optim.linear import LinearOperator
 
 
@@ -26,11 +26,11 @@ def compute_inv_diag_kernel(
     if body_a >= 0:
         Minv_a = gen_inv_mass[body_a]
         J_ia = J_values[constraint_idx, 0]
-        result += wp.dot(J_ia, Minv_a * J_ia)
+        result += wp.dot(J_ia, gm_mul(Minv_a, J_ia))
     if body_b >= 0:
         Minv_b = gen_inv_mass[body_b]
         J_ib = J_values[constraint_idx, 1]
-        result += wp.dot(J_ib, Minv_b * J_ib)
+        result += wp.dot(J_ib, gm_mul(Minv_b, J_ib))
 
     # Add diagonal compliance term C[i,i]
     diag_A = result + C_values[constraint_idx]

--- a/src/axion/types/__init__.py
+++ b/src/axion/types/__init__.py
@@ -1,10 +1,9 @@
 from .contact_interaction import contact_interaction_kernel
 from .contact_interaction import ContactInteraction
-from .generalized_mass import add
 from .generalized_mass import generalized_mass_kernel
 from .generalized_mass import GeneralizedMass
-from .generalized_mass import mul
-from .generalized_mass import scale
+from .generalized_mass import gm_add
+from .generalized_mass import gm_mul
 from .joint_interaction import get_joint_axis_kinematics
 from .joint_interaction import joint_interaction_kernel
 from .joint_interaction import JointAxisKinematics
@@ -19,7 +18,6 @@ __all__ = [
     "JointAxisKinematics",
     "JointInteraction",
     "get_joint_axis_kinematics",
-    "add",
-    "mul",
-    "scale",
+    "gm_add",
+    "gm_mul",
 ]

--- a/src/axion/types/generalized_mass.py
+++ b/src/axion/types/generalized_mass.py
@@ -16,29 +16,21 @@ def add(
 
 
 @wp.func
-def mul(
+def gm_add(
+    a: GeneralizedMass,
+    b: GeneralizedMass,
+) -> GeneralizedMass:
+    return GeneralizedMass(a.m + b.m, a.inertia + b.inertia)
+
+
+@wp.func
+def gm_mul(
     a: GeneralizedMass,
     b: wp.spatial_vector,
 ) -> wp.spatial_vector:
     top = a.inertia @ wp.spatial_top(b)
     bot = a.m * wp.spatial_bottom(b)
     return wp.spatial_vector(top, bot)
-
-
-@wp.func
-def mul(
-    a: wp.spatial_vector,
-    b: GeneralizedMass,
-) -> wp.spatial_vector:
-    top = wp.spatial_top(a) @ b.inertia
-    bot = wp.spatial_bottom(a) * b.m
-    return wp.spatial_vector(top, bot)
-
-
-@wp.func
-def scale(M: GeneralizedMass, s: wp.float32) -> GeneralizedMass:
-    """Scale generalized mass by scalar."""
-    return GeneralizedMass(M.m * s, M.inertia * s)
 
 
 @wp.kernel


### PR DESCRIPTION
Issue number: resolves #5 

-----

## What is the current behavior?
Because of the way how Warp works, the user needs to use star imports so he can use + and * operations. 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- User has to import `gm_add` or `gm_mul` so he can use these basic operations

## Does this introduce a breaking change?

- [ ] Yes  
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->
