### PR TITLE
Add iLQR Jacobian assembly + Helhest bundled-gradient optimizer

### DIFF
--- a/examples/helhest/gradient/trajectory_spline_surface_fast_bundled.py
+++ b/examples/helhest/gradient/trajectory_spline_surface_fast_bundled.py
@@ -1,3 +1,13 @@
+"""Bundled-gradient trajectory optimization for the Helhest robot on a mesh terrain.
+
+Sibling of trajectory_spline_surface_fast.py. Same problem, same loss, same Adam.
+The only change is the gradient: instead of one exact gradient at the nominal
+spline control points, we draw N noise samples around them, run N parallel rollouts,
+and average the N exact gradients before stepping Adam.
+
+Reference: Suh, Pang, Tedrake, "Bundled Gradients through Contact via Randomized
+Smoothing" (2021).
+"""
 import argparse
 import os
 import pathlib
@@ -27,12 +37,7 @@ NUM_WHEEL_DOFS = 3
 
 
 def make_interp_matrix(T: int, K: int) -> tuple[np.ndarray, np.ndarray]:
-    """Build [T, K] linear interpolation weight matrix and per-column normalization.
-
-    W[t, k] is the weight of control point k at timestep t.
-    Expanding:   v = W @ params                          ([T,3] = [T,K] @ [K,3])
-    Contracting: grad_params = (W.T @ grad_v) / col_sums  (average, not sum)
-    """
+    """Build [T, K] linear interpolation weight matrix and per-column normalization."""
     W = np.zeros((T, K), dtype=np.float32)
     for t in range(T):
         k_float = t * (K - 1) / max(T - 1, 1)
@@ -41,7 +46,7 @@ def make_interp_matrix(T: int, K: int) -> tuple[np.ndarray, np.ndarray]:
         alpha = k_float - k_low
         W[t, k_low] += 1.0 - alpha
         W[t, k_high] += alpha
-    col_sums = W.sum(axis=0)  # [K] — total weight each control point receives
+    col_sums = W.sum(axis=0)
     return W, col_sums
 
 
@@ -81,6 +86,11 @@ class SplineAdam:
         return params - lr * m_hat / (np.sqrt(v_hat) + self.eps)
 
 
+# Loss kernels iterate over (timestep, world). The target trajectory is shared across
+# all worlds (read from world 0); each perturbed world contributes its own gradient
+# to the summed loss.
+
+
 @wp.kernel
 def loss_kernel(
     body_pose: wp.array(dtype=wp.transform, ndim=3),
@@ -88,9 +98,8 @@ def loss_kernel(
     weight: float,
     loss: wp.array(dtype=wp.float32),
 ):
-    """L2 distance between chassis position summed over all timesteps."""
-    t = wp.tid()
-    pos = wp.transform_get_translation(body_pose[t, 0, 0])
+    t, w = wp.tid()
+    pos = wp.transform_get_translation(body_pose[t, w, 0])
     target_pos = wp.transform_get_translation(target_body_pose[t, 0, 0])
     delta = pos - target_pos
     wp.atomic_add(loss, 0, weight * wp.dot(delta, delta))
@@ -103,9 +112,8 @@ def yaw_loss_kernel(
     weight: float,
     loss: wp.array(dtype=wp.float32),
 ):
-    """Yaw heading error via forward vector dot product, summed over all timesteps."""
-    t = wp.tid()
-    q = wp.transform_get_rotation(body_pose[t, 0, 0])
+    t, w = wp.tid()
+    q = wp.transform_get_rotation(body_pose[t, w, 0])
     q_target = wp.transform_get_rotation(target_body_pose[t, 0, 0])
     fwd = wp.quat_rotate(q, wp.vec3(1.0, 0.0, 0.0))
     fwd_target = wp.quat_rotate(q_target, wp.vec3(1.0, 0.0, 0.0))
@@ -120,15 +128,20 @@ def regularization_kernel(
     weight: float,
     loss: wp.array(dtype=wp.float32),
 ):
-    """L2 magnitude regularization:  weight * Σ_t ||v_t||² over wheel DOFs."""
-    sim_step, wheel_idx = wp.tid()
-
+    sim_step, w, wheel_idx = wp.tid()
     dof_idx = wheel_dof_offset + wheel_idx
-    v = target_vel[sim_step, 0, dof_idx]
+    v = target_vel[sim_step, w, dof_idx]
     wp.atomic_add(loss, 0, weight * v * v)
 
 
-class HelhestTrajectorySplineSurfaceOptimizer(AxionDifferentiableSimulator):
+class HelhestTrajectorySplineSurfaceBundledOptimizer(AxionDifferentiableSimulator):
+    """Bundled-gradient version of HelhestTrajectorySplineSurfaceOptimizer.
+
+    Each iteration draws N noise samples on spline_params (in [K, 3] space), runs N
+    parallel rollouts (one per world), computes N exact gradients via the batched
+    adjoint, and averages them into a single bundled gradient before stepping Adam.
+    """
+
     def __init__(
         self,
         sim_config: SimulationConfig,
@@ -137,6 +150,9 @@ class HelhestTrajectorySplineSurfaceOptimizer(AxionDifferentiableSimulator):
         engine_config: AxionEngineConfig,
         logging_config: LoggingConfig,
         num_control_points: int = 10,
+        sigma: float = 0.3,
+        sigma_min_ratio: float = 0.1,
+        antithetic: bool = True,
     ):
         super().__init__(
             sim_config,
@@ -147,6 +163,13 @@ class HelhestTrajectorySplineSurfaceOptimizer(AxionDifferentiableSimulator):
         )
 
         self.K = num_control_points
+        self.N = sim_config.num_worlds  # bundled samples = parallel worlds
+        self.sigma_init = sigma
+        self.sigma_min = sigma * sigma_min_ratio
+        self.antithetic = antithetic
+
+        if self.antithetic and self.N % 2 != 0:
+            raise ValueError(f"antithetic=True requires even num_worlds, got {self.N}")
 
         self.loss = wp.zeros(1, dtype=float, requires_grad=True)
         self.trajectory_weight = 10.0
@@ -164,11 +187,13 @@ class HelhestTrajectorySplineSurfaceOptimizer(AxionDifferentiableSimulator):
         # Initial guess (Left, Right, Rear)
         self.init_wheel_vel = (4.0, 4.0, 3.0)
 
+        # Per-iter noise on the spline control points: [N, K, 3]
+        self.noise = np.zeros((self.N, self.K, NUM_WHEEL_DOFS), dtype=np.float64)
+
         self.track_body(body_idx=0, name="chassis", color=(0.0, 0.5, 1.0))
 
     def build_model(self) -> Model:
         self.builder.rigid_gap = 0.2
-        # Joint Control
         TARGET_KE = 250.0
         TARGET_KD = 0.0
 
@@ -225,7 +250,6 @@ class HelhestTrajectorySplineSurfaceOptimizer(AxionDifferentiableSimulator):
         )
 
     def _collect_ghost_shapes(self):
-        """Per-shape data needed to mirror the live robot at the target pose."""
         if hasattr(self, "_ghost_shapes_cache"):
             return self._ghost_shapes_cache
         m = self.model
@@ -264,23 +288,39 @@ class HelhestTrajectorySplineSurfaceOptimizer(AxionDifferentiableSimulator):
         self._ghost_shapes_cache = ghosts
         return ghosts
 
-    def _expand(self, params: np.ndarray) -> np.ndarray:
-        """Expand [K, 3] control points → [T, 3] per-step wheel velocities."""
-        return self.W @ params  # [T, K] @ [K, 3] = [T, 3]
+    def _sample_noise(self, sigma: float) -> np.ndarray:
+        """Draw [N, K, 3] noise. With antithetic, second half mirrors the first."""
+        if self.antithetic:
+            half = self.N // 2
+            base = np.random.randn(half, self.K, NUM_WHEEL_DOFS).astype(np.float64) * sigma
+            return np.concatenate([base, -base], axis=0)
+        return np.random.randn(self.N, self.K, NUM_WHEEL_DOFS).astype(np.float64) * sigma
 
-    def _contract(self, grad_v: np.ndarray) -> np.ndarray:
-        """Contract [T, 3] velocity gradients → [K, 3] control point gradients (normalized average)."""
-        safe_sums = np.where(self.W_col_sums > 0, self.W_col_sums, 1.0)
-        return (self.W.T @ grad_v) / safe_sums[:, None]
+    def _current_sigma(self) -> float:
+        progress = min(self.spline_adam.t / self.spline_adam.total_steps, 1.0)
+        return self.sigma_min + 0.5 * (self.sigma_init - self.sigma_min) * (
+            1.0 + np.cos(np.pi * progress)
+        )
+
+    def _expand_per_world(self, params: np.ndarray) -> np.ndarray:
+        """Expand [K, 3] + [N, K, 3] noise -> [T, N, 3] per-step per-world wheel velocities."""
+        # perturbed[i] = params + noise[i]; then expand each via W: [T, K] @ [K, 3] = [T, 3]
+        perturbed = params[None, :, :] + self.noise  # [N, K, 3]
+        # einsum: tk, nkd -> tnd
+        return np.einsum("tk,nkd->tnd", self.W, perturbed)
 
     def _apply_params(self, params: np.ndarray):
-        """Write expanded spline params into joint_target_vel and per-step controls."""
+        """Resample noise, expand per-world, write into joint_target_vel and per-step controls."""
         T = self.clock.total_sim_steps
         num_dofs = self.trajectory.joint_target_vel.shape[-1]
-        expanded = self._expand(params)  # [T, 3]
 
-        vel_np = np.zeros((T, 1, num_dofs), dtype=np.float32)
-        vel_np[:, 0, WHEEL_DOF_OFFSET : WHEEL_DOF_OFFSET + NUM_WHEEL_DOFS] = expanded
+        self.noise = self._sample_noise(self._current_sigma())
+        expanded = self._expand_per_world(params)  # [T, N, 3]
+
+        vel_np = np.zeros((T, self.N, num_dofs), dtype=np.float32)
+        vel_np[:, :, WHEEL_DOF_OFFSET : WHEEL_DOF_OFFSET + NUM_WHEEL_DOFS] = expanded.astype(
+            np.float32
+        )
 
         wp.copy(self.trajectory.joint_target_vel, wp.array(vel_np, dtype=wp.float32))
         for i in range(T):
@@ -291,7 +331,7 @@ class HelhestTrajectorySplineSurfaceOptimizer(AxionDifferentiableSimulator):
 
         wp.launch(
             kernel=loss_kernel,
-            dim=num_steps,
+            dim=(num_steps, self.N),
             inputs=[
                 self.trajectory.body_pose,
                 self.trajectory.target_body_pose,
@@ -302,7 +342,7 @@ class HelhestTrajectorySplineSurfaceOptimizer(AxionDifferentiableSimulator):
         )
         wp.launch(
             kernel=yaw_loss_kernel,
-            dim=num_steps,
+            dim=(num_steps, self.N),
             inputs=[
                 self.trajectory.body_pose,
                 self.trajectory.target_body_pose,
@@ -313,7 +353,7 @@ class HelhestTrajectorySplineSurfaceOptimizer(AxionDifferentiableSimulator):
         )
         wp.launch(
             kernel=regularization_kernel,
-            dim=(self.clock.total_sim_steps, NUM_WHEEL_DOFS),
+            dim=(self.clock.total_sim_steps, self.N, NUM_WHEEL_DOFS),
             inputs=[
                 self.trajectory.joint_target_vel,
                 WHEEL_DOF_OFFSET,
@@ -324,29 +364,33 @@ class HelhestTrajectorySplineSurfaceOptimizer(AxionDifferentiableSimulator):
         )
 
     def update(self):
-        # Contract: [T, 3] gradients → [K, 3] control point gradients
+        # grad shape: [T, N, num_dofs] — independent gradient per perturbed world
         grad_v = self.trajectory.joint_target_vel.grad.numpy()[
-            :, 0, WHEEL_DOF_OFFSET : WHEEL_DOF_OFFSET + NUM_WHEEL_DOFS
-        ]  # [T, 3]
-        grad_params = self._contract(grad_v)  # [K, 3]
+            :, :, WHEEL_DOF_OFFSET : WHEEL_DOF_OFFSET + NUM_WHEEL_DOFS
+        ]  # [T, N, 3]
+
+        # Per-world spline contraction: [T, N, 3] -> [K, N, 3]
+        safe_sums = np.where(self.W_col_sums > 0, self.W_col_sums, 1.0)
+        grad_per_world = np.einsum("tk,tnd->knd", self.W, grad_v) / safe_sums[:, None, None]
+
+        # Bundled gradient: average across the N noisy samples
+        grad_params = grad_per_world.mean(axis=1)  # [K, 3]
 
         self.trajectory.joint_target_vel.grad.zero_()
-
-        # Adam step on control points
         self.spline_params = self.spline_adam.step(self.spline_params, grad_params)
-
-        # Expand and sync back
-        self._apply_params(self.spline_params)
+        self._apply_params(self.spline_params)  # also resamples noise for next iter
 
     def render(self, train_iter):
         if train_iter % 2 != 0:
             return
 
-        loss_val = self.loss.numpy()[0]
+        # self.loss has been summed across N worlds; divide for per-world comparison
+        loss_val = self.loss.numpy()[0] / self.N
         if loss_val >= self.best_loss:
             return
         self.best_loss = loss_val
 
+        # World 0's trajectory (with its share of noise[0]). Approximate but cheap.
         self._iter_body_poses.append(
             self.trajectory.body_pose.numpy()[:, 0].copy().astype(np.float32)
         )
@@ -363,8 +407,11 @@ class HelhestTrajectorySplineSurfaceOptimizer(AxionDifferentiableSimulator):
         def draw_extras(viewer, step_idx, state):
             viewer.log_scalar("/loss", loss_val)
             idx = min(step_idx, num_steps - 1)
-            target_step = target_poses[idx, 0]  # [num_bodies, 7]
+            target_step = target_poses[idx, 0]
+            bodies_per_world = target_step.shape[0]
             for g in ghost_shapes:
+                if g["body_idx"] >= bodies_per_world:
+                    continue  # shape belongs to a replicated world (N > 1) — skip
                 world_xf = self._compose_xform(target_step[g["body_idx"]], g["local_xform"])
                 name = f"/target_ghost/shape_{g['shape_idx']}"
                 viewer.log_shapes(
@@ -400,7 +447,6 @@ class HelhestTrajectorySplineSurfaceOptimizer(AxionDifferentiableSimulator):
                 self._export_blender_npz(self.export_path)
 
     def _export_blender_npz(self, path: str):
-        """Snapshot model + accumulated trajectories to a single npz for Blender."""
         m = self.model
         shape_body = m.shape_body.numpy()
         shape_transform = m.shape_transform.numpy()
@@ -458,15 +504,15 @@ class HelhestTrajectorySplineSurfaceOptimizer(AxionDifferentiableSimulator):
         newton.eval_fk(self.model, self.model.joint_q, self.model.joint_qd, self.states[0])
         newton.eval_fk(self.model, self.model.joint_q, self.model.joint_qd, self.target_states[0])
 
-        # --- Target episode ---
+        # --- Target episode (replicated across all N worlds, identical controls) ---
         num_dofs = self.trajectory.joint_target_vel.shape[-1]
         T = self.clock.total_sim_steps
 
         for i in range(T):
-            target_ctrl = np.zeros(num_dofs, dtype=np.float32)
-            target_ctrl[WHEEL_DOF_OFFSET + 0] = 5.0
-            target_ctrl[WHEEL_DOF_OFFSET + 1] = 3.0
-            target_ctrl[WHEEL_DOF_OFFSET + 2] = 4.0
+            target_ctrl = np.zeros((self.N, num_dofs), dtype=np.float32)
+            target_ctrl[:, WHEEL_DOF_OFFSET + 0] = 5.0
+            target_ctrl[:, WHEEL_DOF_OFFSET + 1] = 3.0
+            target_ctrl[:, WHEEL_DOF_OFFSET + 2] = 4.0
 
             target_ctrl_wp = wp.array(target_ctrl, dtype=wp.float32, device=self.model.device)
             wp.copy(self.target_controls[i].joint_target_vel, target_ctrl_wp)
@@ -474,19 +520,18 @@ class HelhestTrajectorySplineSurfaceOptimizer(AxionDifferentiableSimulator):
         self.run_target_episode()
 
         # --- Spline setup ---
-        self.W, self.W_col_sums = make_interp_matrix(T, self.K)  # [T, K], [K]
+        self.W, self.W_col_sums = make_interp_matrix(T, self.K)
 
-        # Initialize all control points to the constant initial guess
         self.spline_params = np.array(
             [[self.init_wheel_vel[0], self.init_wheel_vel[1], self.init_wheel_vel[2]]] * self.K,
             dtype=np.float64,
-        )  # [K, 3]
+        )
 
         self.spline_adam = SplineAdam(
             K=self.K, num_dofs=NUM_WHEEL_DOFS, lr=0.11, lr_min_ratio=0.2, total_steps=50
         )
 
-        self._apply_params(self.spline_params)
+        self._apply_params(self.spline_params)  # also samples first noise batch
 
         # --- Optimization ---
         for i in range(iterations):
@@ -495,10 +540,12 @@ class HelhestTrajectorySplineSurfaceOptimizer(AxionDifferentiableSimulator):
             wp.synchronize()
             t_episode = time.perf_counter() - t0
 
-            curr_loss = self.loss.numpy()[0]
+            curr_loss = self.loss.numpy()[0] / self.N  # per-world average
+            sigma_now = self._current_sigma()
             p0 = self.spline_params[0]
             print(
-                f"Iter {i}: Loss={curr_loss:.4f} | cp[0] L={p0[0]:.3f} R={p0[1]:.3f} | K={self.K} | episode={t_episode:.3f}s"
+                f"Iter {i}: Loss={curr_loss:.4f} | cp[0] L={p0[0]:.3f} R={p0[1]:.3f} | "
+                f"K={self.K} N={self.N} sigma={sigma_now:.3f} | episode={t_episode:.3f}s"
             )
 
             self.render(i)
@@ -531,7 +578,38 @@ def main():
         metavar="PATH",
         help="Dump per-iteration trajectory + shape metadata to a .npz for the Blender importer",
     )
+    parser.add_argument(
+        "--num-worlds",
+        type=int,
+        default=32,
+        help="Number of bundled samples (parallel worlds). Even number required if --antithetic.",
+    )
+    parser.add_argument(
+        "--sigma",
+        type=float,
+        default=0.3,
+        help="Initial perturbation scale on spline control points (rad/s).",
+    )
+    parser.add_argument(
+        "--sigma-min-ratio",
+        type=float,
+        default=0.1,
+        help="Final sigma as a fraction of initial (cosine annealed).",
+    )
+    parser.add_argument(
+        "--no-antithetic",
+        action="store_true",
+        help="Disable antithetic sampling (default: enabled, halves variance).",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="RNG seed for noise sampling.",
+    )
     args = parser.parse_args()
+
+    np.random.seed(args.seed)
 
     if args.usd:
         vis_type = "usd"
@@ -543,7 +621,7 @@ def main():
     sim_config = SimulationConfig(
         duration_seconds=5.0,
         target_timestep_seconds=5e-2,
-        num_worlds=1,
+        num_worlds=args.num_worlds,
     )
     render_config = RenderingConfig(
         vis_type=vis_type,
@@ -580,13 +658,16 @@ def main():
         enable_hdf5_logging=False,
     )
 
-    sim = HelhestTrajectorySplineSurfaceOptimizer(
+    sim = HelhestTrajectorySplineSurfaceBundledOptimizer(
         sim_config,
         render_config,
         exec_config,
         engine_config,
         logging_config,
         num_control_points=10,
+        sigma=args.sigma,
+        sigma_min_ratio=args.sigma_min_ratio,
+        antithetic=not args.no_antithetic,
     )
     sim.export_path = args.export
     sim.train(iterations=24)

--- a/test_scripts/test_ilqr_B_jacobian.py
+++ b/test_scripts/test_ilqr_B_jacobian.py
@@ -1,0 +1,305 @@
+"""
+Phase 3.5 of the iLQR plan: assemble the per-step control Jacobian
+B_t = ds+/da and verify against FD.
+
+Scene: single-revolute pendulum hanging from world, with a TARGET_POSITION
+control. State: 1 body, 12 tangent dims. Control: 1 joint dof (target_pos),
+so B_t is 12 x 1.
+
+The same batch-dim repurposing trick used for A_t works here without changes:
+12 worlds, one-hot tangent-output cotangent in each world, single
+step_backward, then read joint_target_pos.grad[w, 0] as the entry for row w
+of B_t. (We also recover A_t simultaneously and sanity-check it.)
+"""
+import os
+os.environ["PYOPENGL_PLATFORM"] = "glx"
+import sys
+sys.path.insert(0, os.path.dirname(__file__))
+
+import numpy as np
+import warp as wp
+import newton
+
+from axion.core.engine import AxionEngine
+from axion.core.engine_config import AxionEngineConfig
+from axion.core.logging_config import LoggingConfig
+from axion.core.model_builder import AxionModelBuilder
+from axion.core.types import JointMode
+
+# Reuse all tangent-space machinery from the A_t test (committed earlier).
+from test_ilqr_jacobian import (
+    perturb_q_tangent,
+    recover_phi_tangent,
+    pushforward_rot_columns,
+)
+
+wp.init()
+
+TANGENT_DIM = 12
+DT = 0.05
+NEWTON_ITERS = 32
+LINEAR_ITERS = 256
+LINEAR_TOL = 1e-10
+NEWTON_ATOL = 1e-9
+
+INIT_JOINT_Q = 0.3            # operating-point joint angle (rad)
+INIT_JOINT_QD = 0.0           # operating-point joint velocity
+TARGET_Q = 0.3                # operating-point target_pos -- equals INIT_JOINT_Q so
+                              # the operating point is at control equilibrium and
+                              # the inexact-Macklin gap (which scales with lambda_c)
+                              # is small enough to read FD-floor accuracy.
+TARGET_KE = 200.0             # P gain
+TARGET_KD = 20.0              # D gain
+
+
+# --------------------------------------------------------------------------
+# Pendulum scene
+# --------------------------------------------------------------------------
+
+def build_pendulum(num_worlds: int):
+    """Single revolute joint to world, with TARGET_POSITION control."""
+    no_collision = newton.ModelBuilder.ShapeConfig(has_shape_collision=False, density=10.0)
+    builder = AxionModelBuilder()
+    link = builder.add_link()
+    builder.add_shape_box(link, hx=0.05, hy=0.05, hz=0.4, cfg=no_collision)
+    j = builder.add_joint_revolute(
+        parent=-1,
+        child=link,
+        axis=wp.vec3(1.0, 0.0, 0.0),
+        parent_xform=wp.transform(wp.vec3(0.0, 0.0, 0.0), wp.quat_identity()),
+        child_xform=wp.transform(wp.vec3(0.0, 0.0, 0.4), wp.quat_identity()),
+        target_ke=TARGET_KE,
+        target_kd=TARGET_KD,
+        label="pendulum_joint",
+        custom_attributes={"joint_dof_mode": [JointMode.TARGET_POSITION]},
+    )
+    builder.add_articulation([j], label="pendulum")
+    return builder.finalize_replicated(num_worlds=num_worlds, gravity=-9.81, requires_grad=True)
+
+
+def make_engine(model, differentiable: bool):
+    config = AxionEngineConfig(
+        max_newton_iters=NEWTON_ITERS,
+        max_linear_iters=LINEAR_ITERS,
+        linear_tol=LINEAR_TOL,
+        linear_atol=LINEAR_TOL,
+        newton_atol=NEWTON_ATOL,
+        enable_linesearch=False,
+        adjoint_soft_blending=False,
+        adjoint_regularization=0.0,
+    )
+    return AxionEngine(
+        model=model,
+        sim_steps=1,
+        config=config,
+        logging_config=LoggingConfig(),
+        differentiable_simulation=differentiable,
+    )
+
+
+def init_state_via_fk(model, joint_q_val: float, joint_qd_val: float):
+    """Set model.joint_q / joint_qd, run FK, return the resulting body state arrays."""
+    jq_np = np.full(model.joint_q.numpy().shape, joint_q_val, dtype=np.float32)
+    jqd_np = np.full(model.joint_qd.numpy().shape, joint_qd_val, dtype=np.float32)
+    wp.copy(model.joint_q, wp.array(jq_np, dtype=wp.float32, device=model.device))
+    wp.copy(model.joint_qd, wp.array(jqd_np, dtype=wp.float32, device=model.device))
+    s = model.state()
+    newton.eval_fk(model, model.joint_q, model.joint_qd, s)
+    return s
+
+
+def make_control(model, target_pos_val: float):
+    ctrl = model.control()
+    tp_np = np.full(ctrl.joint_target_pos.numpy().shape, target_pos_val, dtype=np.float32)
+    wp.copy(ctrl.joint_target_pos, wp.array(tp_np, dtype=wp.float32, device=model.device))
+    return ctrl
+
+
+# --------------------------------------------------------------------------
+# IFT-side assembly
+# --------------------------------------------------------------------------
+
+def assemble_AB_implicit_tangent(engine, model, num_worlds, target_pos_val):
+    assert num_worlds == TANGENT_DIM
+
+    s_template = init_state_via_fk(model, INIT_JOINT_Q, INIT_JOINT_QD)
+    state_in = model.state(); wp.copy(state_in.body_q, s_template.body_q); wp.copy(state_in.body_qd, s_template.body_qd)
+    state_out = model.state()
+    control = make_control(model, target_pos_val)
+
+    contacts = model.collide(state_in)
+    engine.step(state_in, state_out, control, contacts, DT)
+
+    # Operating-point pose for tangent charts.
+    q_minus = np.frombuffer(state_in.body_q.numpy().tobytes(), dtype=np.float32)\
+        .reshape(num_worlds, 1, 7)[0, 0].astype(np.float64).copy()
+    q_plus = np.frombuffer(state_out.body_q.numpy().tobytes(), dtype=np.float32)\
+        .reshape(num_worlds, 1, 7)[0, 0].astype(np.float64).copy()
+
+    G_minus = pushforward_rot_columns(q_minus[3:])
+    G_plus = pushforward_rot_columns(q_plus[3:])
+
+    # Per-world raw cotangents (same setup as the A_t test).
+    pose_grad_np = np.zeros((num_worlds, 1, 7), dtype=np.float32)
+    vel_grad_np = np.zeros((num_worlds, 1, 6), dtype=np.float32)
+    for k in range(TANGENT_DIM):
+        if k < 3:
+            pose_grad_np[k, 0, k] = 1.0
+        elif k < 6:
+            col = 4.0 * G_plus[:, k - 3]
+            pose_grad_np[k, 0, 3:7] = col.astype(np.float32)
+        elif k < 9:
+            vel_grad_np[k, 0, k - 6] = 1.0
+        else:
+            vel_grad_np[k, 0, k - 9 + 3] = 1.0
+
+    wp.copy(engine.data.body_pose_grad,
+            wp.array(pose_grad_np, dtype=wp.transform, device=model.device))
+    wp.copy(engine.data.body_vel_grad,
+            wp.array(vel_grad_np, dtype=wp.spatial_vector, device=model.device))
+
+    engine.data.body_pose_prev.grad.zero_()
+    engine.data.body_vel_prev.grad.zero_()
+    engine.data.zero_gradients()
+
+    engine.step_backward()
+
+    # --- A_t (12x12) ---
+    pose_prev_grad = np.frombuffer(
+        engine.data.body_pose_prev.grad.numpy().tobytes(), dtype=np.float32
+    ).reshape(num_worlds, 1, 7).astype(np.float64)
+    vel_prev_grad = np.frombuffer(
+        engine.data.body_vel_prev.grad.numpy().tobytes(), dtype=np.float32
+    ).reshape(num_worlds, 1, 6).astype(np.float64)
+
+    A = np.zeros((TANGENT_DIM, TANGENT_DIM), dtype=np.float64)
+    for k in range(TANGENT_DIM):
+        raw_pose = pose_prev_grad[k, 0]
+        raw_vel = vel_prev_grad[k, 0]
+        A[k, 0:3] = raw_pose[0:3]
+        A[k, 3:6] = G_minus.T @ raw_pose[3:7]
+        A[k, 6:9] = raw_vel[0:3]
+        A[k, 9:12] = raw_vel[3:6]
+
+    # --- B_t (12 x 1) ---
+    # joint_target_pos.grad[w, j] = dL/d(target_pos[j]) when world w drove
+    # cotangent e_w in tangent output space. So row w of B_t = that row.
+    target_pos_grad = engine.data.joint_target_pos.grad.numpy()  # shape (num_worlds, joint_dof_count)
+    B = np.zeros((TANGENT_DIM, target_pos_grad.shape[1]), dtype=np.float64)
+    for k in range(TANGENT_DIM):
+        B[k, :] = target_pos_grad[k, :].astype(np.float64)
+
+    return A, B, q_plus
+
+
+# --------------------------------------------------------------------------
+# FD-side assembly
+# --------------------------------------------------------------------------
+
+def assemble_B_fd_tangent(model, target_pos_val, eps=1e-3):
+    """Central-difference B_t over joint_target_pos perturbations."""
+    fd_engine = make_engine(model, differentiable=False)
+
+    state_in = model.state()
+    state_out = model.state()
+
+    s_template = init_state_via_fk(model, INIT_JOINT_Q, INIT_JOINT_QD)
+    body_q_template = s_template.body_q.numpy().copy()
+    body_qd_template = s_template.body_qd.numpy().copy()
+
+    def run_at(target_val):
+        wp.copy(state_in.body_q, wp.array(body_q_template, dtype=wp.transform, device=model.device))
+        wp.copy(state_in.body_qd, wp.array(body_qd_template, dtype=wp.spatial_vector, device=model.device))
+        ctrl = make_control(model, target_val)
+        contacts = model.collide(state_in)
+        fd_engine.step(state_in, state_out, ctrl, contacts, DT)
+        q_out = np.frombuffer(state_out.body_q.numpy().tobytes(), dtype=np.float32)\
+            .reshape(1, 1, 7)[0, 0].astype(np.float64).copy()
+        qd_out = np.frombuffer(state_out.body_qd.numpy().tobytes(), dtype=np.float32)\
+            .reshape(1, 1, 6)[0, 0].astype(np.float64).copy()
+        return q_out, qd_out
+
+    q_plus_ref, qd_plus_ref = run_at(target_pos_val)
+    qplus_pos_ref = q_plus_ref[:3]
+    qplus_quat_ref = q_plus_ref[3:]
+    v_plus_ref = qd_plus_ref[:3]
+    w_plus_ref = qd_plus_ref[3:]
+
+    def state_to_tangent(q_out, qd_out):
+        delta_p = q_out[:3] - qplus_pos_ref
+        delta_phi = recover_phi_tangent(q_out[3:], qplus_quat_ref)
+        delta_v = qd_out[:3] - v_plus_ref
+        delta_w = qd_out[3:] - w_plus_ref
+        return np.concatenate([delta_p, delta_phi, delta_v, delta_w])
+
+    sp = run_at(target_pos_val + eps)
+    sm = run_at(target_pos_val - eps)
+    return ((state_to_tangent(*sp) - state_to_tangent(*sm)) / (2.0 * eps)).reshape(-1, 1)
+
+
+# --------------------------------------------------------------------------
+# Driver
+# --------------------------------------------------------------------------
+
+def run_at(target_ke, target_kd, init_joint_q, target_q):
+    """Returns (B_imp, B_fd, max_rel_err, omega_x_imp, omega_x_fd)."""
+    global TARGET_KE, TARGET_KD, INIT_JOINT_Q, TARGET_Q
+    TARGET_KE = target_ke
+    TARGET_KD = target_kd
+    INIT_JOINT_Q = init_joint_q
+    TARGET_Q = target_q
+
+    model_batch = build_pendulum(num_worlds=TANGENT_DIM)
+    engine_batch = make_engine(model_batch, differentiable=True)
+    _, B_imp, _ = assemble_AB_implicit_tangent(engine_batch, model_batch, TANGENT_DIM, TARGET_Q)
+
+    model_fd = build_pendulum(num_worlds=1)
+    B_fd = assemble_B_fd_tangent(model_fd, TARGET_Q, eps=1e-3)
+    diff = np.abs(B_imp - B_fd)
+    rel = diff / (np.abs(B_fd) + 1e-9)
+    return B_imp, B_fd, diff.max(), rel.max(), B_imp[9, 0], B_fd[9, 0]
+
+
+def main():
+    np.set_printoptions(precision=4, suppress=True, linewidth=160)
+
+    # ------- Headline test: at-equilibrium operating point (init_q == target_q).
+    # Inexact-Macklin gradient is exact here because lambda_c = 0 at the operating point.
+    print(f"=== Headline: at-equilibrium operating point ===")
+    print(f"init_q={INIT_JOINT_Q}, init_qd={INIT_JOINT_QD}, target_q={TARGET_Q}, ke={TARGET_KE}, kd={TARGET_KD}")
+
+    B_imp, B_fd, max_abs, max_rel, b_imp_9, b_fd_9 = run_at(
+        TARGET_KE, TARGET_KD, INIT_JOINT_Q, TARGET_Q
+    )
+    print("\nB_implicit:")
+    print(B_imp)
+    print("\nB_FD:")
+    print(B_fd)
+    print(f"\nmax abs err: {max_abs:.3e}")
+    print(f"max rel err: {max_rel:.3e}")
+
+    # Tolerance: relative, sized for the large B-entry magnitude (O(1/dt) scale).
+    rel_tol = 1e-3
+    headline_pass = max_rel < rel_tol
+    print(f"\n{'PASS' if headline_pass else 'FAIL'}: max rel err {max_rel:.3e} {'<' if headline_pass else '>='} {rel_tol}")
+
+    # ------- Diagnostic 1: stiffness sweep -------
+    # If the gap is tied to the constraint operator approximation, error should
+    # roughly track stiffness. If it's tied to "off-target" amount, error tracks
+    # |INIT_JOINT_Q - TARGET_Q|.
+    print("\n=== Diagnostic 1: control stiffness sweep (init_q=0.3, target_q=0.5) ===")
+    print(f"{'ke':>8s}  {'kd':>8s}  {'rel err':>10s}  {'B_imp[9]':>10s}  {'B_fd[9]':>10s}")
+    for ke, kd in [(20.0, 2.0), (50.0, 5.0), (200.0, 20.0), (1000.0, 100.0)]:
+        _, _, _, rel, b_imp_9, b_fd_9 = run_at(ke, kd, 0.3, 0.5)
+        print(f"{ke:8.1f}  {kd:8.1f}  {rel:10.3e}  {b_imp_9:10.4f}  {b_fd_9:10.4f}")
+
+    # ------- Diagnostic 2: at-equilibrium operating point -------
+    print("\n=== Diagnostic 2: equilibrium operating point (init_q == target_q) ===")
+    print(f"{'init_q':>8s}  {'target_q':>10s}  {'rel err':>10s}  {'B_imp[9]':>10s}  {'B_fd[9]':>10s}")
+    for q in (0.0, 0.3, 0.5, 1.0):
+        _, _, _, rel, b_imp_9, b_fd_9 = run_at(200.0, 20.0, q, q)
+        print(f"{q:8.3f}  {q:10.3f}  {rel:10.3e}  {b_imp_9:10.4f}  {b_fd_9:10.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test_scripts/test_ilqr_jacobian.py
+++ b/test_scripts/test_ilqr_jacobian.py
@@ -1,0 +1,441 @@
+"""
+Phase 3 of the iLQR plan: assemble the per-step state-transition Jacobian
+A_t in tangent-space coordinates and verify against tangent-space FD.
+
+Tangent state per body has 12 dims (vs 13 raw):
+    indices 0..2  : delta-position
+    indices 3..5  : delta-rotation as world-frame axis-angle
+    indices 6..8  : delta linear velocity
+    indices 9..11 : delta angular velocity (world frame)
+
+Convention (matches kinematic_mapping.py G_matvec):
+    q+ = (1/2) omega_world (x) q  =>  q(phi) = exp([phi/2; 0]) (x) q_0
+
+i.e. left-multiplication, world-frame angular velocity.
+
+For the IFT side we feed step_backward raw-quat cotangents that are pushforwards
+of tangent unit vectors, then pull the resulting raw-quat input gradients back
+to tangent space.
+
+For the FD side we perturb the operating point in tangent-space directions
+(via exp on the rotation block) and project the output back via log.
+"""
+import os
+os.environ["PYOPENGL_PLATFORM"] = "glx"
+
+import numpy as np
+import warp as wp
+import newton
+
+from axion.core.engine import AxionEngine
+from axion.core.engine_config import AxionEngineConfig
+from axion.core.logging_config import LoggingConfig
+from axion.core.model_builder import AxionModelBuilder
+
+wp.init()
+
+TANGENT_DIM = 12
+DT = 0.05
+NEWTON_ITERS = 32
+LINEAR_ITERS = 256
+LINEAR_TOL = 1e-10
+NEWTON_ATOL = 1e-9
+ANGULAR_VEL = (0.0, 0.0, 0.0)
+
+
+# --------------------------------------------------------------------------
+# Quaternion helpers (warp/newton convention: (x, y, z, w), w = scalar last)
+# --------------------------------------------------------------------------
+
+def quat_mul(a, b):
+    """Hamilton product a (x) b, both in (x, y, z, w) layout."""
+    ax, ay, az, aw = a
+    bx, by, bz, bw = b
+    return np.array([
+        aw * bx + ax * bw + ay * bz - az * by,
+        aw * by - ax * bz + ay * bw + az * bx,
+        aw * bz + ax * by - ay * bx + az * bw,
+        aw * bw - ax * bx - ay * by - az * bz,
+    ], dtype=np.float64)
+
+
+def quat_conj(q):
+    return np.array([-q[0], -q[1], -q[2], q[3]], dtype=np.float64)
+
+
+def quat_exp_pure(phi):
+    """exp([phi; 0]) for axis-angle phi, returning unit quaternion (x,y,z,w)."""
+    phi = np.asarray(phi, dtype=np.float64)
+    norm = np.linalg.norm(phi)
+    if norm < 1e-12:
+        # First-order Taylor: exp([phi; 0]) ~ (phi/2... wait no, phi is whole arg)
+        # exp(0.5 * phi as pure quat with phi as whole vector) -- but here phi
+        # is already the quaternion-log argument, i.e. half-angle * axis.
+        return np.array([phi[0], phi[1], phi[2], 1.0], dtype=np.float64)
+    s = np.sin(norm) / norm
+    return np.array([phi[0] * s, phi[1] * s, phi[2] * s, np.cos(norm)], dtype=np.float64)
+
+
+def quat_log_to_vec(q):
+    """log(q) for unit q, returning the imaginary part of the log (3-vector).
+    For q = (sin(t)*n, cos(t)) returns t*n."""
+    qv = q[:3]
+    qw = q[3]
+    norm_v = np.linalg.norm(qv)
+    if norm_v < 1e-12:
+        return np.zeros(3, dtype=np.float64)
+    angle = np.arctan2(norm_v, qw)
+    return qv / norm_v * angle
+
+
+def perturb_q_tangent(q0, phi):
+    """q = exp([phi/2; 0]) (x) q0  -- world-frame, left-mult convention.
+
+    With phi an axis-angle 3-vector, the rotation magnitude perturbation is |phi|."""
+    return quat_mul(quat_exp_pure(0.5 * phi), q0)
+
+
+def recover_phi_tangent(q, q0):
+    """Inverse of perturb_q_tangent: phi = 2 * log(q (x) q0^-1)."""
+    return 2.0 * quat_log_to_vec(quat_mul(q, quat_conj(q0)))
+
+
+def pushforward_rot_columns(q0):
+    """Columns of the 4x3 pushforward matrix M_push for the rotation block:
+    M_push[:, k] = (1/2) (e_k_pure_imag (x) q0)
+    where the leading 1/2 comes from d(exp(phi/2)) / d(phi)|_{phi=0}.
+
+    This is the linearisation of  q(phi) = exp([phi/2; 0]) (x) q0  at phi=0."""
+    e0 = np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float64)
+    e1 = np.array([0.0, 1.0, 0.0, 0.0], dtype=np.float64)
+    e2 = np.array([0.0, 0.0, 1.0, 0.0], dtype=np.float64)
+    cols = [0.5 * quat_mul(e, q0) for e in (e0, e1, e2)]
+    return np.stack(cols, axis=1)   # shape (4, 3)
+
+
+# --------------------------------------------------------------------------
+# Engine setup (unchanged from Phase 1/2)
+# --------------------------------------------------------------------------
+
+def build_box(num_worlds: int):
+    no_collision = newton.ModelBuilder.ShapeConfig(has_shape_collision=False, density=10.0)
+    builder = AxionModelBuilder()
+    link = builder.add_link()
+    builder.add_shape_box(link, hx=0.2, hy=0.3, hz=0.4, cfg=no_collision)
+    j = builder.add_joint_free(child=link)
+    builder.add_articulation([j], label="floating_box")
+    return builder.finalize_replicated(num_worlds=num_worlds, gravity=-9.81, requires_grad=True)
+
+
+def make_engine(model, differentiable: bool):
+    config = AxionEngineConfig(
+        max_newton_iters=NEWTON_ITERS,
+        max_linear_iters=LINEAR_ITERS,
+        linear_tol=LINEAR_TOL,
+        linear_atol=LINEAR_TOL,
+        newton_atol=NEWTON_ATOL,
+        enable_linesearch=False,
+        adjoint_soft_blending=False,
+        adjoint_regularization=0.0,
+    )
+    return AxionEngine(
+        model=model,
+        sim_steps=1,
+        config=config,
+        logging_config=LoggingConfig(),
+        differentiable_simulation=differentiable,
+    )
+
+
+def operating_point_arrays(num_worlds: int, device, q_override=None, qd_override=None):
+    """Same operating point in every world."""
+    pos = np.array([0.1, -0.2, 1.5], dtype=np.float32)
+    axis = np.array([1.0, 1.0, 0.0]) / np.sqrt(2.0)
+    angle = 0.4
+    quat = np.array(
+        [axis[0] * np.sin(angle / 2),
+         axis[1] * np.sin(angle / 2),
+         axis[2] * np.sin(angle / 2),
+         np.cos(angle / 2)],
+        dtype=np.float32,
+    )
+
+    body_q = np.zeros((num_worlds, 1, 7), dtype=np.float32)
+    body_q[:, 0, :3] = pos
+    body_q[:, 0, 3:] = quat
+
+    body_qd = np.zeros((num_worlds, 1, 6), dtype=np.float32)
+    body_qd[:, 0, :3] = [0.7, -0.3, 0.5]
+    body_qd[:, 0, 3:] = ANGULAR_VEL
+
+    if q_override is not None:
+        body_q[:, 0, :] = q_override
+    if qd_override is not None:
+        body_qd[:, 0, :] = qd_override
+
+    return (
+        wp.array(body_q, dtype=wp.transform, device=device, requires_grad=True),
+        wp.array(body_qd, dtype=wp.spatial_vector, device=device, requires_grad=True),
+    )
+
+
+def operating_point_np():
+    """Same content as operating_point_arrays, returned as plain numpy."""
+    pos = np.array([0.1, -0.2, 1.5], dtype=np.float64)
+    axis = np.array([1.0, 1.0, 0.0]) / np.sqrt(2.0)
+    angle = 0.4
+    quat = np.array(
+        [axis[0] * np.sin(angle / 2),
+         axis[1] * np.sin(angle / 2),
+         axis[2] * np.sin(angle / 2),
+         np.cos(angle / 2)],
+        dtype=np.float64,
+    )
+    body_q = np.concatenate([pos, quat])           # 7
+    body_qd = np.concatenate([[0.7, -0.3, 0.5], list(ANGULAR_VEL)])  # 6
+    return body_q.astype(np.float64), body_qd.astype(np.float64)
+
+
+# --------------------------------------------------------------------------
+# IFT-side assembly (12 worlds)
+# --------------------------------------------------------------------------
+
+def assemble_A_implicit_tangent(engine, model, num_worlds):
+    assert num_worlds == TANGENT_DIM
+
+    state_in = model.state()
+    state_out = model.state()
+    control = model.control()
+
+    body_q, body_qd = operating_point_arrays(num_worlds, model.device)
+    state_in.body_q = body_q
+    state_in.body_qd = body_qd
+
+    contacts = model.collide(state_in)
+    engine.step(state_in, state_out, control, contacts, DT)
+
+    q_minus_np, _ = operating_point_np()
+    q_plus = np.frombuffer(state_out.body_q.numpy().tobytes(), dtype=np.float32)\
+        .reshape(num_worlds, 1, 7)[0, 0].astype(np.float64).copy()
+    qd_plus = np.frombuffer(state_out.body_qd.numpy().tobytes(), dtype=np.float32)\
+        .reshape(num_worlds, 1, 6)[0, 0].astype(np.float64).copy()
+
+    # Pushforward matrices for the rotation block at the input and output points.
+    G_minus = pushforward_rot_columns(q_minus_np[3:])    # 4 x 3, evaluated at q^-_0
+    G_plus = pushforward_rot_columns(q_plus[3:])         # 4 x 3, evaluated at q^+_0
+
+    # Build per-world raw cotangents.
+    # Tangent layout (12): [dp(3), dphi(3), dv(3), dw(3)]
+    # Raw layout: body_pose_grad has 7 (px, py, pz, qx, qy, qz, qw),
+    #             body_vel_grad has 6 (vx, vy, vz, wx, wy, wz).
+    #
+    # For tangent output cotangent e_k (unit in tangent space):
+    #   - dp_k (k in 0..2): raw pose cotangent = (e_k^pos, 0_quat),  raw vel cotangent = 0.
+    #   - dphi_k (k in 3..5): raw pose cotangent = (0_pos, 2 * G_plus[:, k-3]),  raw vel = 0.
+    #     The "2 *" is because  M_pull = 4 G^T  =>  (M_pull)^T e_k = 4 G e_k = 2 * G_plus_col.
+    #     Wait, columns of G are (1/2) e_q (x) q+, so 2 * column = e_q (x) q+. We feed that
+    #     directly as the raw quaternion cotangent.
+    #   - dv_k (k in 6..8): raw vel cotangent = (e_k-6^lin, 0_ang).
+    #   - dw_k (k in 9..11): raw vel cotangent = (0_lin, e_k-9^ang).
+    # Output cotangent for tangent-output direction k (rotation rows):
+    #   nabla_q+ L = (M_pull_+)^T e_k.
+    # Since columns of M_push_+ are m_k = (1/2) e_k_quat (x) q+_0 with squared norm 1/4,
+    # the (Moore-Penrose) M_pull_+ = 4 (M_push_+)^T, so (M_pull_+)^T = 4 M_push_+.
+    # Hence nabla_q+ L = 4 * G_plus[:, k-3].
+    pose_grad_np = np.zeros((num_worlds, 1, 7), dtype=np.float32)
+    vel_grad_np = np.zeros((num_worlds, 1, 6), dtype=np.float32)
+    for k in range(TANGENT_DIM):
+        if k < 3:                       # dp_k
+            pose_grad_np[k, 0, k] = 1.0
+        elif k < 6:                     # dphi_k
+            col = 4.0 * G_plus[:, k - 3]
+            pose_grad_np[k, 0, 3:7] = col.astype(np.float32)
+        elif k < 9:                     # dv_k
+            vel_grad_np[k, 0, k - 6] = 1.0
+        else:                           # dw_k
+            vel_grad_np[k, 0, k - 9 + 3] = 1.0
+
+    wp.copy(
+        engine.data.body_pose_grad,
+        wp.array(pose_grad_np, dtype=wp.transform, device=model.device),
+    )
+    wp.copy(
+        engine.data.body_vel_grad,
+        wp.array(vel_grad_np, dtype=wp.spatial_vector, device=model.device),
+    )
+
+    engine.data.body_pose_prev.grad.zero_()
+    engine.data.body_vel_prev.grad.zero_()
+    engine.data.zero_gradients()
+
+    engine.step_backward()
+
+    pose_prev_grad = np.frombuffer(
+        engine.data.body_pose_prev.grad.numpy().tobytes(), dtype=np.float32
+    ).reshape(num_worlds, 1, 7).astype(np.float64)
+    vel_prev_grad = np.frombuffer(
+        engine.data.body_vel_prev.grad.numpy().tobytes(), dtype=np.float32
+    ).reshape(num_worlds, 1, 6).astype(np.float64)
+
+    # Pull raw input gradients to tangent space.
+    # For input layout: tangent indices 0..2 = pos (identity), 3..5 = rot (use G_minus^T / 2),
+    # 6..8 = lin vel (identity), 9..11 = ang vel (identity).
+    A = np.zeros((TANGENT_DIM, TANGENT_DIM), dtype=np.float64)
+    for k in range(TANGENT_DIM):
+        raw_pose = pose_prev_grad[k, 0]   # 7-vec
+        raw_vel = vel_prev_grad[k, 0]     # 6-vec
+        # Position columns (input)
+        A[k, 0:3] = raw_pose[0:3]
+        # Rotation columns (input): chain rule says nabla_xi- L = (M_push_-)^T nabla_q- L,
+        # i.e. just G_minus^T @ raw_quat_grad with no extra scaling.
+        raw_quat = raw_pose[3:7]          # 4-vec
+        A[k, 3:6] = G_minus.T @ raw_quat
+        # Linear vel
+        A[k, 6:9] = raw_vel[0:3]
+        # Angular vel
+        A[k, 9:12] = raw_vel[3:6]
+
+    return A, q_plus, qd_plus
+
+
+# --------------------------------------------------------------------------
+# FD-side assembly (1 world)
+# --------------------------------------------------------------------------
+
+def assemble_A_fd_tangent(model, eps_pos=1e-4, eps_rot=1e-4, eps_vel=1e-4):
+    fd_engine = make_engine(model, differentiable=False)
+
+    state_in = model.state()
+    state_out = model.state()
+    control = model.control()
+
+    q0_np, qd0_np = operating_point_np()
+    q0_pos = q0_np[:3].copy()
+    q0_quat = q0_np[3:].copy()
+
+    def run_at(q_np, qd_np):
+        q_arr = wp.array(q_np.reshape(1, 1, 7).astype(np.float32),
+                         dtype=wp.transform, device=model.device)
+        qd_arr = wp.array(qd_np.reshape(1, 1, 6).astype(np.float32),
+                          dtype=wp.spatial_vector, device=model.device)
+        wp.copy(state_in.body_q, q_arr)
+        wp.copy(state_in.body_qd, qd_arr)
+        contacts = model.collide(state_in)
+        fd_engine.step(state_in, state_out, control, contacts, DT)
+        q_out = np.frombuffer(state_out.body_q.numpy().tobytes(), dtype=np.float32)\
+            .reshape(1, 1, 7)[0, 0].astype(np.float64).copy()
+        qd_out = np.frombuffer(state_out.body_qd.numpy().tobytes(), dtype=np.float32)\
+            .reshape(1, 1, 6)[0, 0].astype(np.float64).copy()
+        return q_out, qd_out
+
+    # Reference forward at the operating point.
+    q_plus_ref, qd_plus_ref = run_at(q0_np, qd0_np)
+    qplus_pos_ref = q_plus_ref[:3]
+    qplus_quat_ref = q_plus_ref[3:]
+    v_plus_ref = qd_plus_ref[:3]
+    w_plus_ref = qd_plus_ref[3:]
+
+    A_fd = np.zeros((TANGENT_DIM, TANGENT_DIM), dtype=np.float64)
+
+    def state_to_tangent(q_out, qd_out):
+        """Project a forward-step result to the 12-dim tangent space at the reference s+."""
+        delta_p = q_out[:3] - qplus_pos_ref
+        delta_phi = recover_phi_tangent(q_out[3:], qplus_quat_ref)
+        delta_v = qd_out[:3] - v_plus_ref
+        delta_w = qd_out[3:] - w_plus_ref
+        return np.concatenate([delta_p, delta_phi, delta_v, delta_w])
+
+    for j in range(TANGENT_DIM):
+        if j < 3:                      # dp_j
+            eps = eps_pos
+            q_p = q0_np.copy(); q_p[j] += eps
+            q_m = q0_np.copy(); q_m[j] -= eps
+            qd_p = qd0_np.copy(); qd_m = qd0_np.copy()
+        elif j < 6:                    # dphi_j (axis-angle)
+            eps = eps_rot
+            phi_p = np.zeros(3); phi_p[j - 3] = eps
+            phi_m = np.zeros(3); phi_m[j - 3] = -eps
+            q_p = q0_np.copy()
+            q_m = q0_np.copy()
+            q_p[3:] = perturb_q_tangent(q0_quat, phi_p)
+            q_m[3:] = perturb_q_tangent(q0_quat, phi_m)
+            qd_p = qd0_np.copy(); qd_m = qd0_np.copy()
+        elif j < 9:                    # dv_j
+            eps = eps_vel
+            qd_p = qd0_np.copy(); qd_p[j - 6] += eps
+            qd_m = qd0_np.copy(); qd_m[j - 6] -= eps
+            q_p = q0_np.copy(); q_m = q0_np.copy()
+        else:                          # dw_j
+            eps = eps_vel
+            qd_p = qd0_np.copy(); qd_p[(j - 9) + 3] += eps
+            qd_m = qd0_np.copy(); qd_m[(j - 9) + 3] -= eps
+            q_p = q0_np.copy(); q_m = q0_np.copy()
+
+        sp = run_at(q_p, qd_p)
+        sm = run_at(q_m, qd_m)
+        delta_plus = state_to_tangent(*sp)
+        delta_minus = state_to_tangent(*sm)
+        A_fd[:, j] = (delta_plus - delta_minus) / (2.0 * eps)
+
+    return A_fd, q_plus_ref, qd_plus_ref
+
+
+# --------------------------------------------------------------------------
+# Driver
+# --------------------------------------------------------------------------
+
+def run_one(angular_vel):
+    global ANGULAR_VEL
+    ANGULAR_VEL = tuple(angular_vel)
+
+    model_batch = build_box(num_worlds=TANGENT_DIM)
+    engine_batch = make_engine(model_batch, differentiable=True)
+    A_imp, _, _ = assemble_A_implicit_tangent(engine_batch, model_batch, TANGENT_DIM)
+
+    model_fd = build_box(num_worlds=1)
+    A_fd, _, _ = assemble_A_fd_tangent(model_fd)
+
+    diff = np.abs(A_imp - A_fd)
+
+    # Block-wise breakdown: rotation (rows 3..5), angular-velocity (rows 9..11).
+    rot_diff = diff[3:6, :].max()
+    angvel_diff = diff[9:12, 9:12].max()
+
+    return diff.max(), rot_diff, angvel_diff, A_imp, A_fd
+
+
+def main():
+    np.set_printoptions(precision=4, suppress=True, linewidth=160)
+
+    print("=== Test 1: omega = 0  (gyroscopic Jacobian inactive) ===")
+    err, rot_err, angvel_err, A_imp, A_fd = run_one((0.0, 0.0, 0.0))
+    print(f"max abs err overall: {err:.3e}")
+    print(f"max abs err rot rows : {rot_err:.3e}")
+    print(f"max abs err angvel block: {angvel_err:.3e}")
+
+    print("\nA_implicit (12x12 tangent):")
+    print(A_imp)
+    print("\nA_FD (12x12 tangent):")
+    print(A_fd)
+    print("\nA_implicit - A_FD:")
+    print(A_imp - A_fd)
+
+    tol = 5e-4
+    headline_pass = err < tol
+    print(f"\n{'PASS' if headline_pass else 'FAIL'}: max abs err {err:.3e} {'<' if headline_pass else '>='} {tol}\n")
+
+    print("=== Test 2: gyroscopic-Jacobian error scaling (tangent space) ===")
+    print(f"{'|w|':>8s}  {'max overall':>12s}  {'max rot-block':>14s}  {'max angvel-block':>17s}")
+    for omega_mag in (0.0, 0.05, 0.1, 0.2, 0.4, 0.8):
+        ax = np.array([0.4, 0.1, -0.2])
+        ax = ax / np.linalg.norm(ax) * omega_mag if omega_mag > 0 else ax * 0.0
+        full_err, rot_err, angvel_err, _, _ = run_one(tuple(ax.tolist()))
+        print(f"{omega_mag:8.3f}  {full_err:12.3e}  {rot_err:14.3e}  {angvel_err:17.3e}")
+
+    print()
+    if headline_pass:
+        print("PASS: tangent-space A_t agrees with FD on all 12 directions at omega=0.")
+
+
+if __name__ == "__main__":
+    main()

--- a/test_scripts/test_ilqr_riccati.py
+++ b/test_scripts/test_ilqr_riccati.py
@@ -1,0 +1,507 @@
+"""
+Phase 5 of the iLQR plan: trajectory-level A_t, B_t assembly + Riccati
+backward pass + closed-loop stability check + one iLQR forward rollout.
+
+Scene: single revolute pendulum (same as B_t test). Nominal trajectory:
+hold at INIT_JOINT_Q with constant target_pos. Quadratic cost penalises
+tangent-state deviation from a target tangent state plus control effort.
+
+Pipeline per iteration:
+  1. Roll out the nominal trajectory across 12 worlds.
+  2. At each step t, run engine.step then engine.step_backward with one-hot
+     tangent cotangents to extract A_t (12x12) and B_t (12x1).
+  3. Run Riccati backward (numpy) to get gains K_t (1x12), k_t (1x1).
+  4. Forward rollout with linear feedback u_t' = u_t + alpha*k_t + K_t*dx_t.
+  5. Report closed-loop stability + cost before/after.
+"""
+import os
+os.environ["PYOPENGL_PLATFORM"] = "glx"
+import sys
+sys.path.insert(0, os.path.dirname(__file__))
+
+import numpy as np
+import warp as wp
+import newton
+
+from axion.core.engine import AxionEngine
+from axion.core.engine_config import AxionEngineConfig
+from axion.core.logging_config import LoggingConfig
+from axion.core.model_builder import AxionModelBuilder
+from axion.core.types import JointMode
+
+from test_ilqr_jacobian import (
+    perturb_q_tangent,
+    recover_phi_tangent,
+    pushforward_rot_columns,
+)
+
+wp.init()
+
+TANGENT_DIM = 12
+DT = 0.05
+N_STEPS = 10
+NEWTON_ITERS = 32
+LINEAR_ITERS = 256
+LINEAR_TOL = 1e-10
+NEWTON_ATOL = 1e-9
+
+INIT_JOINT_Q = 0.0
+INIT_JOINT_QD = 0.0
+TARGET_KE = 20.0          # softer than the B_t test so dynamics are slow enough to control
+TARGET_KD = 2.0
+TARGET_GOAL = 0.6         # joint angle the trajectory should drive to
+
+
+# --------------------------------------------------------------------------
+# Pendulum scene + helpers (same as B_t test)
+# --------------------------------------------------------------------------
+
+def build_pendulum(num_worlds: int):
+    no_collision = newton.ModelBuilder.ShapeConfig(has_shape_collision=False, density=10.0)
+    builder = AxionModelBuilder()
+    link = builder.add_link()
+    builder.add_shape_box(link, hx=0.05, hy=0.05, hz=0.4, cfg=no_collision)
+    j = builder.add_joint_revolute(
+        parent=-1,
+        child=link,
+        axis=wp.vec3(1.0, 0.0, 0.0),
+        parent_xform=wp.transform(wp.vec3(0.0, 0.0, 0.0), wp.quat_identity()),
+        child_xform=wp.transform(wp.vec3(0.0, 0.0, 0.4), wp.quat_identity()),
+        target_ke=TARGET_KE,
+        target_kd=TARGET_KD,
+        label="pendulum_joint",
+        custom_attributes={"joint_dof_mode": [JointMode.TARGET_POSITION]},
+    )
+    builder.add_articulation([j], label="pendulum")
+    return builder.finalize_replicated(num_worlds=num_worlds, gravity=-9.81, requires_grad=True)
+
+
+def make_engine(model, differentiable: bool):
+    config = AxionEngineConfig(
+        max_newton_iters=NEWTON_ITERS,
+        max_linear_iters=LINEAR_ITERS,
+        linear_tol=LINEAR_TOL,
+        linear_atol=LINEAR_TOL,
+        newton_atol=NEWTON_ATOL,
+        enable_linesearch=False,
+        adjoint_soft_blending=False,
+        adjoint_regularization=0.0,
+    )
+    return AxionEngine(
+        model=model,
+        sim_steps=N_STEPS,
+        config=config,
+        logging_config=LoggingConfig(),
+        differentiable_simulation=differentiable,
+    )
+
+
+def init_state_via_fk(model, joint_q_val: float, joint_qd_val: float):
+    jq_np = np.full(model.joint_q.numpy().shape, joint_q_val, dtype=np.float32)
+    jqd_np = np.full(model.joint_qd.numpy().shape, joint_qd_val, dtype=np.float32)
+    wp.copy(model.joint_q, wp.array(jq_np, dtype=wp.float32, device=model.device))
+    wp.copy(model.joint_qd, wp.array(jqd_np, dtype=wp.float32, device=model.device))
+    s = model.state()
+    newton.eval_fk(model, model.joint_q, model.joint_qd, s)
+    return s
+
+
+def make_control(model, target_pos_val: float):
+    ctrl = model.control()
+    tp_np = np.full(ctrl.joint_target_pos.numpy().shape, target_pos_val, dtype=np.float32)
+    wp.copy(ctrl.joint_target_pos, wp.array(tp_np, dtype=wp.float32, device=model.device))
+    return ctrl
+
+
+def transform_to_np(arr, num_worlds, num_bodies):
+    return np.frombuffer(arr.numpy().tobytes(), dtype=np.float32)\
+        .reshape(num_worlds, num_bodies, 7).astype(np.float64)
+
+
+def vel_to_np(arr, num_worlds, num_bodies):
+    return np.frombuffer(arr.numpy().tobytes(), dtype=np.float32)\
+        .reshape(num_worlds, num_bodies, 6).astype(np.float64)
+
+
+# --------------------------------------------------------------------------
+# Per-step Jacobian assembly (one timestep)
+# --------------------------------------------------------------------------
+
+def setup_one_hot_cotangents(num_worlds, q_plus_np):
+    """Build per-world raw cotangents for tangent-space output rows."""
+    G_plus = pushforward_rot_columns(q_plus_np[3:])
+    pose_grad_np = np.zeros((num_worlds, 1, 7), dtype=np.float32)
+    vel_grad_np = np.zeros((num_worlds, 1, 6), dtype=np.float32)
+    for k in range(TANGENT_DIM):
+        if k < 3:
+            pose_grad_np[k, 0, k] = 1.0
+        elif k < 6:
+            col = 4.0 * G_plus[:, k - 3]
+            pose_grad_np[k, 0, 3:7] = col.astype(np.float32)
+        elif k < 9:
+            vel_grad_np[k, 0, k - 6] = 1.0
+        else:
+            vel_grad_np[k, 0, k - 9 + 3] = 1.0
+    return pose_grad_np, vel_grad_np
+
+
+def extract_AB_from_grads(engine, num_worlds, q_minus_np):
+    """Read body_pose_prev.grad and body_vel_prev.grad, project to tangent."""
+    G_minus = pushforward_rot_columns(q_minus_np[3:])
+    pose_prev_grad = np.frombuffer(
+        engine.data.body_pose_prev.grad.numpy().tobytes(), dtype=np.float32
+    ).reshape(num_worlds, 1, 7).astype(np.float64)
+    vel_prev_grad = np.frombuffer(
+        engine.data.body_vel_prev.grad.numpy().tobytes(), dtype=np.float32
+    ).reshape(num_worlds, 1, 6).astype(np.float64)
+
+    A = np.zeros((TANGENT_DIM, TANGENT_DIM), dtype=np.float64)
+    for k in range(TANGENT_DIM):
+        raw_pose = pose_prev_grad[k, 0]
+        raw_vel = vel_prev_grad[k, 0]
+        A[k, 0:3] = raw_pose[0:3]
+        A[k, 3:6] = G_minus.T @ raw_pose[3:7]
+        A[k, 6:9] = raw_vel[0:3]
+        A[k, 9:12] = raw_vel[3:6]
+
+    target_pos_grad = engine.data.joint_target_pos.grad.numpy()
+    n_dof = target_pos_grad.shape[1]
+    B = np.zeros((TANGENT_DIM, n_dof), dtype=np.float64)
+    for k in range(TANGENT_DIM):
+        B[k, :] = target_pos_grad[k, :].astype(np.float64)
+
+    return A, B
+
+
+# --------------------------------------------------------------------------
+# Trajectory rollout + assembly
+# --------------------------------------------------------------------------
+
+def rollout_and_assemble(model, engine, init_q, init_qd, target_pos_traj):
+    """Run N forward steps, assembling A_t, B_t at each step.
+
+    init_q: (1, 1, 7) numpy, initial body_q (will be replicated across worlds).
+    init_qd: (1, 1, 6) numpy.
+    target_pos_traj: list[float] of length N, target_pos at each step.
+
+    Returns: A_traj (N, 12, 12), B_traj (N, 12, 1),
+             body_q_traj (N+1, 7), body_qd_traj (N+1, 6).
+    """
+    num_worlds = TANGENT_DIM
+    state_in = model.state()
+    state_out = model.state()
+
+    init_q_full = np.tile(init_q, (num_worlds, 1, 1)).astype(np.float32)
+    init_qd_full = np.tile(init_qd, (num_worlds, 1, 1)).astype(np.float32)
+    wp.copy(state_in.body_q,
+            wp.array(init_q_full, dtype=wp.transform, device=model.device))
+    wp.copy(state_in.body_qd,
+            wp.array(init_qd_full, dtype=wp.spatial_vector, device=model.device))
+
+    body_q_traj = [init_q[0, 0].astype(np.float64).copy()]
+    body_qd_traj = [init_qd[0, 0].astype(np.float64).copy()]
+    A_traj = []
+    B_traj = []
+
+    for t in range(N_STEPS):
+        ctrl = make_control(model, target_pos_traj[t])
+        contacts = model.collide(state_in)
+
+        # Snapshot operating-point input pose (world 0) before step.
+        q_minus = transform_to_np(state_in.body_q, num_worlds, 1)[0, 0]
+
+        engine.step(state_in, state_out, ctrl, contacts, DT)
+
+        # Snapshot output pose.
+        q_plus = transform_to_np(state_out.body_q, num_worlds, 1)[0, 0]
+        qd_plus = vel_to_np(state_out.body_qd, num_worlds, 1)[0, 0]
+        body_q_traj.append(q_plus)
+        body_qd_traj.append(qd_plus)
+
+        # Per-world cotangents for tangent output dims.
+        pose_grad_np, vel_grad_np = setup_one_hot_cotangents(num_worlds, q_plus)
+        wp.copy(engine.data.body_pose_grad,
+                wp.array(pose_grad_np, dtype=wp.transform, device=model.device))
+        wp.copy(engine.data.body_vel_grad,
+                wp.array(vel_grad_np, dtype=wp.spatial_vector, device=model.device))
+
+        engine.data.body_pose_prev.grad.zero_()
+        engine.data.body_vel_prev.grad.zero_()
+        engine.data.zero_gradients()
+
+        engine.step_backward()
+        A, B = extract_AB_from_grads(engine, num_worlds, q_minus)
+        A_traj.append(A)
+        B_traj.append(B)
+
+        # Advance state_in for the next step.
+        wp.copy(state_in.body_q, state_out.body_q)
+        wp.copy(state_in.body_qd, state_out.body_qd)
+
+    return (
+        np.stack(A_traj, axis=0),
+        np.stack(B_traj, axis=0),
+        np.array(body_q_traj),
+        np.array(body_qd_traj),
+    )
+
+
+# --------------------------------------------------------------------------
+# Tangent-space deviation between two states
+# --------------------------------------------------------------------------
+
+def tangent_diff(q_a, qd_a, q_b, qd_b):
+    """x_a (boxminus) x_b in 12-dim tangent coords."""
+    delta_p = q_a[:3] - q_b[:3]
+    delta_phi = recover_phi_tangent(q_a[3:], q_b[3:])
+    delta_v = qd_a[:3] - qd_b[:3]
+    delta_w = qd_a[3:] - qd_b[3:]
+    return np.concatenate([delta_p, delta_phi, delta_v, delta_w])
+
+
+# --------------------------------------------------------------------------
+# Riccati backward
+# --------------------------------------------------------------------------
+
+def riccati_backward(A_traj, B_traj, Q, R, Qf, x_devs, u_devs):
+    """Time-varying iLQR backward pass on the linearised dynamics.
+
+    A_traj: (N, n, n), B_traj: (N, n, m).
+    Q, R: stage cost Hessians. Qf: terminal cost Hessian.
+    x_devs: (N+1, n) state deviations from x_target on the nominal trajectory.
+    u_devs: (N, m) control deviations from u_target on the nominal trajectory.
+
+    Returns:
+      K_traj (N, m, n) feedback gains, k_traj (N, m) feedforward terms,
+      V_xx_traj (N+1, n, n), V_x_traj (N+1, n).
+    """
+    N = A_traj.shape[0]
+    n = A_traj.shape[1]
+    m = B_traj.shape[2]
+
+    V_xx = Qf.copy()
+    V_x = Qf @ x_devs[N]
+
+    K_traj = np.zeros((N, m, n))
+    k_traj = np.zeros((N, m))
+    V_xx_traj = np.zeros((N + 1, n, n))
+    V_x_traj = np.zeros((N + 1, n))
+    V_xx_traj[N] = V_xx
+    V_x_traj[N] = V_x
+
+    for t in range(N - 1, -1, -1):
+        A = A_traj[t]
+        B = B_traj[t]
+        l_x = Q @ x_devs[t]
+        l_u = R @ u_devs[t]
+
+        Q_x = l_x + A.T @ V_x
+        Q_u = l_u + B.T @ V_x
+        Q_xx = Q + A.T @ V_xx @ A
+        Q_uu = R + B.T @ V_xx @ B
+        Q_ux = B.T @ V_xx @ A
+
+        Q_uu_reg = Q_uu + 1e-9 * np.eye(m)   # tiny regularisation
+        K = -np.linalg.solve(Q_uu_reg, Q_ux)
+        k = -np.linalg.solve(Q_uu_reg, Q_u)
+
+        V_xx = Q_xx + K.T @ Q_uu @ K + K.T @ Q_ux + Q_ux.T @ K
+        V_xx = 0.5 * (V_xx + V_xx.T)
+        V_x = Q_x + K.T @ Q_uu @ k + K.T @ Q_u + Q_ux.T @ k
+
+        K_traj[t] = K
+        k_traj[t] = k
+        V_xx_traj[t] = V_xx
+        V_x_traj[t] = V_x
+
+    return K_traj, k_traj, V_xx_traj, V_x_traj
+
+
+# --------------------------------------------------------------------------
+# Forward rollout with linear feedback
+# --------------------------------------------------------------------------
+
+def forward_rollout_with_feedback(model, engine_fd, init_q, init_qd,
+                                   nominal_target_pos, K_traj, k_traj,
+                                   nominal_q_traj, nominal_qd_traj,
+                                   alpha=1.0):
+    """Roll out 1 world with u_t' = u_nom + alpha*k_t + K_t * (x_t' boxminus x_nom_t)."""
+    state_in = model.state()
+    state_out = model.state()
+
+    wp.copy(state_in.body_q,
+            wp.array(init_q.astype(np.float32), dtype=wp.transform, device=model.device))
+    wp.copy(state_in.body_qd,
+            wp.array(init_qd.astype(np.float32), dtype=wp.spatial_vector, device=model.device))
+
+    q_traj = [init_q[0, 0].astype(np.float64).copy()]
+    qd_traj = [init_qd[0, 0].astype(np.float64).copy()]
+    u_traj = []
+    for t in range(N_STEPS):
+        q_now = transform_to_np(state_in.body_q, 1, 1)[0, 0]
+        qd_now = vel_to_np(state_in.body_qd, 1, 1)[0, 0]
+        x_dev = tangent_diff(q_now, qd_now, nominal_q_traj[t], nominal_qd_traj[t])
+
+        u_new = nominal_target_pos[t] + alpha * k_traj[t][0] + K_traj[t][0] @ x_dev
+        u_traj.append(u_new)
+
+        ctrl = make_control(model, float(u_new))
+        contacts = model.collide(state_in)
+        engine_fd.step(state_in, state_out, ctrl, contacts, DT)
+
+        q_traj.append(transform_to_np(state_out.body_q, 1, 1)[0, 0].copy())
+        qd_traj.append(vel_to_np(state_out.body_qd, 1, 1)[0, 0].copy())
+        wp.copy(state_in.body_q, state_out.body_q)
+        wp.copy(state_in.body_qd, state_out.body_qd)
+
+    return np.array(q_traj), np.array(qd_traj), np.array(u_traj)
+
+
+# --------------------------------------------------------------------------
+# Driver
+# --------------------------------------------------------------------------
+
+def trajectory_cost(q_traj, qd_traj, u_traj, q_target_traj, qd_target_traj,
+                     u_target_traj, Q_diag, R_diag, Qf_diag):
+    """Sum_t 0.5 (x_t - x_t^*)^T Q (x_t - x_t^*) + 0.5 (u_t - u_t^*)^T R (u_t - u_t^*)
+    + 0.5 terminal."""
+    N = u_traj.shape[0]
+    cost = 0.0
+    for t in range(N):
+        x_dev = tangent_diff(q_traj[t], qd_traj[t], q_target_traj[t], qd_target_traj[t])
+        u_dev = u_traj[t] - u_target_traj[t]
+        cost += 0.5 * x_dev @ (Q_diag * x_dev)
+        cost += 0.5 * u_dev * R_diag * u_dev
+    x_dev = tangent_diff(q_traj[N], qd_traj[N], q_target_traj[N], qd_target_traj[N])
+    cost += 0.5 * x_dev @ (Qf_diag * x_dev)
+    return float(cost)
+
+
+def main():
+    np.set_printoptions(precision=4, suppress=True, linewidth=160)
+
+    # --- Build batch (12-world) and 1-world models ---
+    model_batch = build_pendulum(num_worlds=TANGENT_DIM)
+    engine_batch = make_engine(model_batch, differentiable=True)
+    model_fd = build_pendulum(num_worlds=1)
+    engine_fd = make_engine(model_fd, differentiable=False)
+
+    # --- Initial state and nominal control sequence ---
+    # Nominal control: ramp target_pos from 0 to TARGET_GOAL across N steps.
+    # The pendulum lags this ramp because of finite stiffness, so the rollout is
+    # genuinely off-equilibrium and Riccati has interesting work to do.
+    s0_batch = init_state_via_fk(model_batch, INIT_JOINT_Q, INIT_JOINT_QD)
+    init_q = transform_to_np(s0_batch.body_q, TANGENT_DIM, 1)[0:1, 0:1].astype(np.float32)
+    init_qd = vel_to_np(s0_batch.body_qd, TANGENT_DIM, 1)[0:1, 0:1].astype(np.float32)
+
+    target_pos_traj = np.linspace(0.0, TARGET_GOAL, N_STEPS, dtype=np.float64)
+
+    # --- Rollout + Jacobian assembly ---
+    A_traj, B_traj, q_traj_nom, qd_traj_nom = rollout_and_assemble(
+        model_batch, engine_batch, init_q, init_qd, target_pos_traj
+    )
+
+    # Joint angle estimate (body_y / sin and body_z / cos give angle from -X^.body axis).
+    def theta_estimate(q):
+        return np.arctan2(q[1], -q[2])
+
+    print(f"Rollout: N={N_STEPS}, dt={DT}, target_pos ramp 0 -> {TARGET_GOAL}")
+    print(f"Nominal trajectory (body angle vs ramp):")
+    print(f"{'t':>3s}  {'target':>8s}  {'theta_actual':>13s}  {'tracking_err':>13s}")
+    for t in range(N_STEPS + 1):
+        target = target_pos_traj[min(t, N_STEPS - 1)]
+        theta = theta_estimate(q_traj_nom[t])
+        print(f"{t:3d}  {target:8.4f}  {theta:13.4f}  {target - theta:13.4f}")
+
+    # --- Quadratic cost in tangent space ---
+    # Heavy weight on phi_x (joint angle) and omega_x (joint velocity) -- the
+    # only physically free DoFs of the pendulum. Light weight on the rest, so
+    # the spurious unit eigenvalues from the missing constraint-Jacobian term
+    # in the adjoint contribute little to the cost-to-go.
+    Q_diag = np.array([0.01, 0.01, 0.01,
+                       100.0, 0.01, 0.01,    # heavy weight on phi_x (axis-angle around X = joint axis)
+                       0.01, 0.01, 0.01,
+                       1.0, 0.01, 0.01])      # weight on omega_x
+    Qf_diag = 100.0 * Q_diag
+    Q = np.diag(Q_diag)
+    R = np.array([[0.01]])
+    Qf = np.diag(Qf_diag)
+
+    # Target tangent trajectory: hold at INIT (theta=0), so the iLQR is asked
+    # to drive the pendulum BACK toward 0 against the open-loop ramp.
+    # Nominal trajectory deviations from this target = (x_nominal - x_target).
+    x_devs = np.zeros((N_STEPS + 1, TANGENT_DIM))
+    for t in range(N_STEPS + 1):
+        x_devs[t] = tangent_diff(q_traj_nom[t], qd_traj_nom[t],
+                                  q_traj_nom[0], qd_traj_nom[0])
+    u_devs = (target_pos_traj - 0.0).reshape(-1, 1)
+
+    K_traj, k_traj, V_xx_traj, V_x_traj = riccati_backward(
+        A_traj, B_traj, Q, R, Qf, x_devs, u_devs
+    )
+
+    # --- Spectral diagnostic (with caveat) ---
+    # The unit eigenvalues you'll see in A_t come from a missing
+    # J_b * dphi/dq- term in the adjoint -- the constrained directions look
+    # uncontrollable to the linearisation but the simulator squashes them in
+    # one step. So spectral radius is misleading; what matters is the rollout.
+    print(f"\nA_t spectral radii (open vs closed loop) -- spurious unit eigenvalues "
+          f"come from constrained directions; ignore for stability assessment:")
+    for t in (0, N_STEPS // 2, N_STEPS - 1):
+        rho_open = np.max(np.abs(np.linalg.eigvals(A_traj[t])))
+        rho_closed = np.max(np.abs(np.linalg.eigvals(A_traj[t] + B_traj[t] @ K_traj[t])))
+        print(f"  t={t:2d}  rho(A)={rho_open:.4f}  rho(A+BK)={rho_closed:.4f}")
+
+    # --- Cost: nominal vs improved (apply feedforward k_traj + feedback K_traj) ---
+    q_target_traj = q_traj_nom.copy()
+    qd_target_traj = qd_traj_nom.copy()
+    # Make the target stay at theta=0 (the initial state) for all t -> Riccati's job is to drive back.
+    for t in range(N_STEPS + 1):
+        q_target_traj[t] = q_traj_nom[0]
+        qd_target_traj[t] = qd_traj_nom[0]
+    u_target_traj = np.zeros(N_STEPS)
+
+    cost_nominal = trajectory_cost(q_traj_nom, qd_traj_nom, target_pos_traj,
+                                    q_target_traj, qd_target_traj, u_target_traj,
+                                    Q_diag, 0.01, Qf_diag)
+    print(f"\nNominal trajectory cost: {cost_nominal:.4f}")
+
+    print(f"\nFeedforward k_t and feedback K_t[phi_x] = K_t[0, 3]:")
+    for t in range(N_STEPS):
+        print(f"  t={t:2d}  k={k_traj[t][0]:+.4f}  K[phi_x]={K_traj[t][0, 3]:+.4f}")
+
+    # --- Rollouts at varying line-search step sizes ---
+    print(f"\nLine-searched iLQR forward step:")
+    print(f"  {'alpha':>8s}  {'cost':>12s}  {'final_theta':>12s}  {'mean|u|':>10s}")
+    best_cost = cost_nominal
+    best_alpha = 0.0
+    for alpha in (0.0, 0.25, 0.5, 1.0):
+        q_new, qd_new, u_new = forward_rollout_with_feedback(
+            model_fd, engine_fd, init_q, init_qd, target_pos_traj,
+            K_traj, k_traj, q_traj_nom, qd_traj_nom, alpha=alpha
+        )
+        c = trajectory_cost(q_new, qd_new, u_new,
+                            q_target_traj, qd_target_traj, u_target_traj,
+                            Q_diag, 0.01, Qf_diag)
+        print(f"  {alpha:8.2f}  {c:12.4f}  {theta_estimate(q_new[-1]):12.4f}  {np.mean(np.abs(u_new)):10.4f}")
+        if alpha == 1.0:
+            print(f"   alpha=1.0 trajectory:")
+            for t in range(N_STEPS + 1):
+                theta_t = theta_estimate(q_new[t])
+                u_t = u_new[t] if t < N_STEPS else float('nan')
+                print(f"    t={t:2d}  theta={theta_t:+.4f}  u={u_t:+.4f}")
+        if c < best_cost:
+            best_cost = c
+            best_alpha = alpha
+
+    cost_decreased = best_cost < cost_nominal
+    print(f"\nbest alpha = {best_alpha}, cost {cost_nominal:.4f} -> {best_cost:.4f}")
+    if cost_decreased:
+        print(f"PASS: one iLQR backward+forward step decreased the cost by "
+              f"{cost_nominal - best_cost:.4f} ({100 * (1 - best_cost/cost_nominal):.1f}%)")
+    else:
+        print(f"FAIL: no positive line-search step decreased the cost.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Two unrelated bodies of work bundled into one PR:

**iLQR Jacobian assembly (3 commits)**
- Adds tangent-space iLQR Jacobian assembly with finite-difference verification.
- Adds B_t (controls Jacobian) test on a single-revolute pendulum.
- Adds end-to-end iLQR sanity test covering rollout, Riccati backward sweep, and forward feedback.

**Helhest bundled-gradient trajectory optimizer (1 commit)**
- New \`trajectory_spline_surface_fast_bundled.py\`: sibling of the exact-gradient optimizer that averages N parallel-rollout gradients per Adam step (Suh, Pang, Tedrake 2021, randomized smoothing).
- Tightens \`contact_compliance\` from \`0.1\` to \`1e-10\` in the exact-gradient script for a harder contact baseline.
- Minor line-wrap reformats.

## Test plan

- [ ] iLQR sanity test passes (\`pytest\` on the new test file)
- [ ] Tangent-space FD test passes
- [ ] B_t pendulum test passes
- [ ] Bundled-gradient script runs end-to-end on the existing Helhest scene
- [ ] Exact-gradient script still converges with the tighter \`contact_compliance\`