### PR TITLE
Add CUDA-event profiler for forward simulation steps

### DIFF
--- a/examples/conf/engine/axion_profile_e2e.yaml
+++ b/examples/conf/engine/axion_profile_e2e.yaml
@@ -1,0 +1,9 @@
+# @package engine
+# AxionEngineConfig with end-to-end forward-step profiling enabled.
+# Coarse breakdown of one engine.step:
+#   load_data | warm_start_copy | nr_solve | backtracking | output_copy
+defaults:
+  - axion
+  - _self_
+
+profiling_mode: end_to_end

--- a/examples/conf/engine/axion_profile_per_iter.yaml
+++ b/examples/conf/engine/axion_profile_per_iter.yaml
@@ -1,0 +1,11 @@
+# @package engine
+# AxionEngineConfig with per-iteration NR profiling enabled.
+# Replaces wp.capture_while inside _solve with a fixed-K Python `for`,
+# which means NO early exit (every step pays max_newton_iters iterations).
+# Phases timed per NR iteration:
+#   linear_system | preconditioner | cr_solve | step_or_linesearch | convergence_check
+defaults:
+  - axion
+  - _self_
+
+profiling_mode: per_component

--- a/examples/conf/execution/profile.yaml
+++ b/examples/conf/execution/profile.yaml
@@ -1,0 +1,7 @@
+# @package execution
+# Execution preset for forward-step profiling. Forces the captured graph
+# to contain exactly one engine.step (steps_per_segment=1) so that CUDA
+# events recorded inside the graph fire once per replay.
+_target_: axion.ExecutionConfig
+use_cuda_graph: True
+headless_steps_per_segment: 1

--- a/src/axion/__init__.py
+++ b/src/axion/__init__.py
@@ -1,6 +1,7 @@
 from .core import AxionEngine
 from .core import AxionEngineConfig
 from .core import EngineConfig
+from .core import EngineProfiler
 from .core import FeatherstoneEngineConfig
 from .core import JointMode
 from .core import LoggingConfig
@@ -20,6 +21,7 @@ __all__ = [
     "AxionEngine",
     "EngineConfig",
     "AxionEngineConfig",
+    "EngineProfiler",
     "FeatherstoneEngineConfig",
     "MuJoCoEngineConfig",
     "SemiImplicitEngineConfig",

--- a/src/axion/core/__init__.py
+++ b/src/axion/core/__init__.py
@@ -7,6 +7,7 @@ from .engine_config import FeatherstoneEngineConfig
 from .engine_config import MuJoCoEngineConfig
 from .engine_config import SemiImplicitEngineConfig
 from .engine_config import XPBDEngineConfig
+from .engine_profiler import EngineProfiler
 from .logging_config import LoggingConfig
 from .types import JointMode
 
@@ -15,6 +16,7 @@ __all__ = [
     "AxionEngine",
     "EngineConfig",
     "AxionEngineConfig",
+    "EngineProfiler",
     "FeatherstoneEngineConfig",
     "MuJoCoEngineConfig",
     "SemiImplicitEngineConfig",

--- a/src/axion/core/base_engine.py
+++ b/src/axion/core/base_engine.py
@@ -22,6 +22,7 @@ from .dataset_logger import DatasetHDF5Logger
 from .engine_config import AxionEngineConfig
 from .engine_data import EngineData
 from .engine_dims import EngineDimensions
+from .engine_profiler import EngineProfiler
 from .linear_utils import compute_dbody_qd_from_dbody_lambda
 from .linear_utils import compute_linear_system
 from .linesearch_utils import perform_linesearch
@@ -169,6 +170,12 @@ class AxionEngineBase(SolverBase):
             )
 
         self.timestep = wp.zeros(1, dtype=wp.int32, device=self.device)
+
+        self.profiler = EngineProfiler(
+            mode=config.profiling_mode,
+            max_newton_iters=config.max_newton_iters,
+            device=self.device,
+        )
 
     def _save_iter_to_history(self):
         if not self.logging_config.enable_hdf5_logging:
@@ -322,13 +329,28 @@ class AxionEngineBase(SolverBase):
         # =========================================================================
         # Solve non-linear system with Newton-Raphson (NR) method
         # =========================================================================
-        def nr_loop():
+        prof = self.profiler
+        per_component = prof.enabled and prof.mode == "per_component"
+        end_to_end = prof.enabled and prof.mode == "end_to_end"
+
+        def nr_loop_step(slot_idx: int = 0):
+            """One NR iteration, optionally bracketed by per-phase events.
+
+            ``slot_idx`` is the unrolled iteration index used to address
+            the profiler event ring; pass 0 for the captured-while path.
+            """
             self.data.keep_running.zero_()
-            # Linearize
+
+            if per_component:
+                prof.record_boundary(0, slot_idx)
             compute_linear_system(
                 self.axion_model, self.axion_contacts, self.data, self.config, self.dims
             )
+            if per_component:
+                prof.record_boundary(1, slot_idx)
             self.preconditioner.update()
+            if per_component:
+                prof.record_boundary(2, slot_idx)
 
             # Linear Solve
             self.data._dconstr_force.zero_()
@@ -345,6 +367,8 @@ class AxionEngineBase(SolverBase):
             compute_dbody_qd_from_dbody_lambda(self.axion_model, self.data, self.config, self.dims)
 
             wp.copy(dest=self.data._constr_force_prev_iter, src=self.data._constr_force)
+            if per_component:
+                prof.record_boundary(3, slot_idx)
 
             if self.config.enable_linesearch:
                 perform_linesearch(
@@ -356,23 +380,37 @@ class AxionEngineBase(SolverBase):
                     self.axion_model, self.axion_contacts, self.data, self.config, self.dims
                 )
                 self.data.tiled_sq_norm.compute(self.data.res.full, self.data.res_norm_sq)
+            if per_component:
+                prof.record_boundary(4, slot_idx)
 
             self.data.save_state_to_candidates()
             self._save_iter_to_history()
             self._check_convergence()
+            if per_component:
+                prof.record_boundary(5, slot_idx)
 
         # Run the NR loop
         self.data.keep_running.fill_(1)
         self.data.iter_count.zero_()
-        if self.device.is_capturing:
-            wp.capture_while(self.data.keep_running, nr_loop)
+        if per_component:
+            # Fixed unroll for per-iteration profiling. No early exit:
+            # the loop always pays max_newton_iters iters regardless of
+            # convergence. Convergence-check still runs and updates
+            # keep_running for downstream code that inspects it.
+            for k in range(self.config.max_newton_iters):
+                nr_loop_step(slot_idx=k)
+        elif self.device.is_capturing:
+            wp.capture_while(self.data.keep_running, lambda: nr_loop_step(0))
         else:
             # Fallback for eager execution (no graph)
             while True:
-                nr_loop()
+                nr_loop_step(0)
                 if self.data.keep_running.numpy()[0] == 0:
                     break
 
+        if end_to_end:
+            # boundary 4: end of NR loop, start of backtracking
+            prof.record_boundary(4)
         perform_backtracking(self.axion_model, self.data, self.config, self.dims)
         if self.logger:
             self.logger.capture_step(self.timestep, self.data)

--- a/src/axion/core/engine.py
+++ b/src/axion/core/engine.py
@@ -30,7 +30,20 @@ class AxionEngine(AxionEngineBase):
         contacts: Contacts,
         dt: float,
     ):
+        prof = self.profiler
+        end_to_end = prof.enabled and prof.mode == "end_to_end"
+        # End-to-end phase boundaries (matches END_TO_END_PHASES order):
+        # 0: collide-start (simulator) | 1: load_data-start
+        # 2: warm_start_copy-start    | 3: nr_solve-start
+        # 4: backtracking-start (in _solve) | 5: output_copy-start
+        # 6: output_copy-end
+        # The simulator brackets the collide phase (boundaries 0 -> 1);
+        # the engine brackets the rest.
+        if end_to_end:
+            prof.record_boundary(1)
         self.load_data(state_in, control, contacts, dt)
+        if end_to_end:
+            prof.record_boundary(2)
 
         # Initial guess: use current state (zero-order warm start)
         wp.copy(dest=self.data.body_pose, src=state_in.body_q)
@@ -38,8 +51,15 @@ class AxionEngine(AxionEngineBase):
 
         self.data._constr_force.zero_()
         self.data._constr_force_prev_iter.zero_()
+        if end_to_end:
+            prof.record_boundary(3)
 
+        # _solve emits boundary 4 (NR-end / backtracking-start) internally.
         self._solve()
+        if end_to_end:
+            prof.record_boundary(5)
 
         wp.copy(dest=state_out.body_q, src=self.data.body_pose)
         wp.copy(dest=state_out.body_qd, src=self.data.body_vel)
+        if end_to_end:
+            prof.record_boundary(6)

--- a/src/axion/core/engine_config.py
+++ b/src/axion/core/engine_config.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 from typing import Any
 from typing import Optional
 
+from .engine_profiler import VALID_MODES as _VALID_PROFILING_MODES
+
 
 @dataclass(frozen=True)
 class EngineConfig:
@@ -113,6 +115,13 @@ class AxionEngineConfig(EngineConfig):
     log_linear_system_data: bool = True
     log_constraint_data: bool = True
 
+    # --- Profiling ---
+    # "off" | "end_to_end" | "per_component". See engine_profiler.py for the
+    # phase breakdown each mode emits. ``per_component`` replaces the
+    # capture_while NR loop with a fixed unroll of length max_newton_iters,
+    # so it forces the worst-case iteration cost every step.
+    profiling_mode: str = "off"
+
     @property
     def num_linesearch_steps(self):
         num_steps = self.linesearch_conservative_step_count
@@ -208,6 +217,12 @@ class AxionEngineConfig(EngineConfig):
                 )
 
         _validate_positive_int(self.max_contacts_per_world, "max_contacts_per_world")
+
+        if self.profiling_mode not in _VALID_PROFILING_MODES:
+            raise ValueError(
+                f"profiling_mode must be one of {_VALID_PROFILING_MODES}, "
+                f"got {self.profiling_mode!r}"
+            )
 
 
 @dataclass(frozen=True)

--- a/src/axion/core/engine_profiler.py
+++ b/src/axion/core/engine_profiler.py
@@ -1,0 +1,236 @@
+"""Event-based profiler for AxionEngine forward steps.
+
+Two modes, both intended to run with ``use_cuda_graph=True``:
+
+- ``"end_to_end"`` — events bracket the major coarse phases of one
+  ``engine.step`` (``load_data``, warm-start copy, NR solve, backtracking,
+  output copy). Useful for "where does one step spend its time?" at the
+  Python-callable granularity.
+
+- ``"per_component"`` — replaces ``wp.capture_while`` inside ``_solve``
+  with a fixed unroll of length ``max_newton_iters``. Events sit between
+  the per-iteration phases (linear system / preconditioner / CR solve /
+  step-or-linesearch / convergence). Trades early-exit for a clean
+  per-iteration breakdown.
+
+Usage protocol
+--------------
+The captured graph must contain exactly **one** ``engine.step`` call so
+that each event-record node fires once per replay. The host then replays
+the graph R times, calling :meth:`EngineProfiler.collect` after each
+replay (which syncs and accumulates). :meth:`summary` returns
+mean/p50/p95 in milliseconds.
+
+If the graph contains N>1 step calls, the records get overwritten N times
+within one replay and only the last copy's timestamps survive — see the
+module docstring caveat in ``base_engine.py`` for context.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Literal
+from typing import Optional
+
+import numpy as np
+import warp as wp
+
+
+ProfilingMode = Literal["off", "end_to_end", "per_component"]
+VALID_MODES = ("off", "end_to_end", "per_component")
+
+
+# Phase tags used by each mode. Keep in sync with the record sites in
+# AxionEngineBase.
+END_TO_END_PHASES = (
+    "collide",
+    "load_data",
+    "warm_start_copy",
+    "nr_solve",
+    "backtracking",
+    "output_copy",
+)
+
+PER_COMPONENT_PHASES = (
+    "linear_system",
+    "preconditioner",
+    "cr_solve",
+    "step_or_linesearch",
+    "convergence_check",
+)
+
+
+@dataclass
+class _PhaseStats:
+    samples_ms: list = field(default_factory=list)
+
+    def add(self, ms: float):
+        self.samples_ms.append(ms)
+
+    def stats(self):
+        if not self.samples_ms:
+            return {"count": 0}
+        a = np.asarray(self.samples_ms, dtype=np.float64)
+        return {
+            "count": int(a.size),
+            "mean_ms": float(a.mean()),
+            "p50_ms": float(np.percentile(a, 50)),
+            "p95_ms": float(np.percentile(a, 95)),
+            "min_ms": float(a.min()),
+            "max_ms": float(a.max()),
+            "total_ms": float(a.sum()),
+        }
+
+
+class EngineProfiler:
+    """Pre-allocated CUDA-event pools + per-replay accumulation.
+
+    Built around two patterns:
+
+    - ``end_to_end``: one event slot per phase boundary. The captured
+      graph touches each ``record_event(...)`` node once per replay.
+
+    - ``per_component``: ``K_unroll + 1`` slots per phase boundary, indexed
+      by the unrolled NR iteration.
+
+    The caller (the engine) is responsible for calling
+    :meth:`record_boundary` at each phase boundary inside the graph, and
+    for calling :meth:`collect` after every ``wp.capture_launch`` it wants
+    to count.
+    """
+
+    def __init__(self, mode: ProfilingMode, max_newton_iters: int, device):
+        if mode not in VALID_MODES:
+            raise ValueError(
+                f"profiling mode must be one of {VALID_MODES}, got {mode!r}"
+            )
+        self._mode = mode
+        self.device = device
+        self._enabled = mode != "off"
+        # Number of unrolled NR iterations under per_component mode. Sized
+        # to max_newton_iters so the unroll covers the worst case the
+        # engine could ever run.
+        self._n_iters = max_newton_iters
+
+        if not self._enabled:
+            self._events = {}
+            self._stats = {}
+            return
+
+        if mode == "end_to_end":
+            phases = END_TO_END_PHASES
+            slots = 1
+        else:  # per_component
+            phases = PER_COMPONENT_PHASES
+            slots = max_newton_iters
+
+        # boundaries = phases + 1 (start of phase 0 ... end of last phase)
+        self._phase_names = phases
+        self._slots = slots
+        self._events = [
+            [
+                wp.Event(device=device, enable_timing=True)
+                for _ in range(slots)
+            ]
+            for _ in range(len(phases) + 1)
+        ]
+        # Latched at capture time: True iff record_boundary(i, ...) was
+        # ever called. Phases whose start or end boundary is unrecorded
+        # are skipped by collect() (and reported as "n/a" in summary).
+        # This lets callers leave phases un-bracketed (e.g. the smoke
+        # test exercises engine.step directly with no collide phase).
+        self._boundary_recorded = [False] * (len(phases) + 1)
+        self._stats = {p: _PhaseStats() for p in phases}
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @property
+    def mode(self) -> ProfilingMode:
+        return self._mode
+
+    @property
+    def n_iters(self) -> int:
+        """Length of the unrolled NR loop under per_component mode."""
+        return self._n_iters
+
+    def record_boundary(self, boundary_idx: int, slot_idx: int = 0):
+        """Record a CUDA event at boundary ``boundary_idx``, slot ``slot_idx``.
+
+        For ``end_to_end`` (slots=1), pass ``slot_idx=0``. For
+        ``per_component``, pass the unrolled NR iteration index.
+        """
+        if not self._enabled:
+            return
+        wp.record_event(self._events[boundary_idx][slot_idx])
+        self._boundary_recorded[boundary_idx] = True
+
+    def collect(self):
+        """Sync events and accumulate one replay's per-phase elapsed times.
+
+        Call after every ``wp.capture_launch`` whose execution should be
+        counted. Synchronizes only the boundary events, so it is cheap
+        relative to ``wp.synchronize()``.
+        """
+        if not self._enabled:
+            return
+        # Sync the latest recorded event so the elapsed-time reads below
+        # don't race the GPU. Walk back from the final boundary to find
+        # the last boundary that was actually recorded.
+        last_recorded = next(
+            (i for i in range(len(self._boundary_recorded) - 1, -1, -1)
+             if self._boundary_recorded[i]),
+            None,
+        )
+        if last_recorded is None:
+            return  # nothing was bracketed this window
+        wp.synchronize_event(self._events[last_recorded][self._slots - 1])
+
+        for p_idx, phase in enumerate(self._phase_names):
+            if not (self._boundary_recorded[p_idx] and self._boundary_recorded[p_idx + 1]):
+                continue
+            stats = self._stats[phase]
+            for s in range(self._slots):
+                ms = wp.get_event_elapsed_time(
+                    self._events[p_idx][s],
+                    self._events[p_idx + 1][s],
+                    synchronize=False,
+                )
+                stats.add(ms)
+
+    def reset(self):
+        if not self._enabled:
+            return
+        for p in self._phase_names:
+            self._stats[p] = _PhaseStats()
+
+    def summary(self) -> dict:
+        """Return per-phase {count, mean/p50/p95/min/max/total ms}."""
+        if not self._enabled:
+            return {}
+        return {p: self._stats[p].stats() for p in self._phase_names}
+
+    def print_summary(self, header: Optional[str] = None):
+        if not self._enabled:
+            print("[EngineProfiler] disabled (mode='off')")
+            return
+        print("=" * 72)
+        print(header or f"[EngineProfiler] mode={self._mode}")
+        print("-" * 72)
+        s = self.summary()
+        total = sum(v.get("mean_ms", 0.0) for v in s.values())
+        print(f"{'phase':<24}{'count':>8}{'mean':>10}{'p50':>10}{'p95':>10}{'share':>10}")
+        for phase, v in s.items():
+            if v["count"] == 0:
+                print(f"{phase:<24}{0:>8}")
+                continue
+            share = v["mean_ms"] / total if total > 0 else 0.0
+            print(
+                f"{phase:<24}{v['count']:>8}{v['mean_ms']:>10.3f}"
+                f"{v['p50_ms']:>10.3f}{v['p95_ms']:>10.3f}{share*100:>9.1f}%"
+            )
+        print("-" * 72)
+        print(f"{'sum of means':<24}{'':>8}{total:>10.3f}")
+        print("=" * 72)

--- a/src/axion/simulation/base_simulator.py
+++ b/src/axion/simulation/base_simulator.py
@@ -8,6 +8,7 @@ from typing import Optional
 
 import newton
 import warp as wp
+from axion.core.engine import AxionEngine
 from axion.core.engine_config import EngineConfig
 from axion.core.logging_config import LoggingConfig
 from axion.core.model_builder import AxionModelBuilder
@@ -110,7 +111,13 @@ class BaseSimulator(ABC):
         """Performs one fundamental integration step of the simulation."""
         self.current_state.clear_forces()
 
-        # Detect collisions
+        # End_to_end profiling: mark the start of the "collide" phase. The
+        # engine closes the phase by recording boundary 1 at engine.step
+        # entry, so the elapsed window covers collide + the trivial Python
+        # gap (control_policy, viewer.apply_forces) before engine.step.
+        prof = self.solver.profiler if isinstance(self.solver, AxionEngine) else None
+        if prof is not None and prof.enabled and prof.mode == "end_to_end":
+            prof.record_boundary(0)
         self.contacts = self.model.collide(self.current_state)
 
         self.control_policy(self.current_state)

--- a/src/axion/simulation/dataset_simulator.py
+++ b/src/axion/simulation/dataset_simulator.py
@@ -338,6 +338,16 @@ class DatasetSimulator(BaseSimulator, ABC):
             if isinstance(self.solver, AxionEngine):
                 # self.solver.events.print_timings()
                 self.solver.save_logs()
+                if self.solver.profiler.enabled:
+                    if self.steps_per_segment != 1:
+                        print(
+                            f"WARNING: profiler enabled but steps_per_segment="
+                            f"{self.steps_per_segment}; only the LAST step in each "
+                            "segment is timed. For accurate stats, set "
+                            "execution.headless_steps_per_segment=1 (headless) or "
+                            "match render fps to dt."
+                        )
+                    self.solver.profiler.print_summary()
 
             if self.rendering_config.vis_type == "usd":
                 self.viewer.close()
@@ -366,6 +376,10 @@ class DatasetSimulator(BaseSimulator, ABC):
             self._capture_cuda_graphs()
 
         wp.capture_launch(self.cuda_graph)
+
+        # See InteractiveSimulator for the profiler-hook rationale.
+        if isinstance(self.solver, AxionEngine) and self.solver.profiler.enabled:
+            self.solver.profiler.collect()
 
     def _capture_cuda_graphs(self):
         n_steps = self.steps_per_segment

--- a/src/axion/simulation/interactive_simulator.py
+++ b/src/axion/simulation/interactive_simulator.py
@@ -75,6 +75,16 @@ class InteractiveSimulator(BaseSimulator, ABC):
             if isinstance(self.solver, AxionEngine):
                 # self.solver.events.print_timings()
                 self.solver.save_logs()
+                if self.solver.profiler.enabled:
+                    if self.steps_per_segment != 1:
+                        print(
+                            f"WARNING: profiler enabled but steps_per_segment="
+                            f"{self.steps_per_segment}; only the LAST step in each "
+                            "segment is timed. For accurate stats, set "
+                            "execution.headless_steps_per_segment=1 (headless) or "
+                            "match render fps to dt."
+                        )
+                    self.solver.profiler.print_summary()
 
             if self.rendering_config.vis_type == "usd":
                 self.viewer.close()
@@ -132,6 +142,13 @@ class InteractiveSimulator(BaseSimulator, ABC):
             print(f"segment: {(t1 - t0) * 1000:.2f} ms total, ~{ms_per_step:.2f} ms/step")
         else:
             wp.capture_launch(self.cuda_graph)
+
+        # Profiler hook: read back per-replay event timings. Only valid
+        # when the captured graph contains exactly one engine.step (i.e.
+        # steps_per_segment == 1); otherwise events get overwritten by
+        # the unrolled copies and only the last copy's times survive.
+        if isinstance(self.solver, AxionEngine) and self.solver.profiler.enabled:
+            self.solver.profiler.collect()
 
     def _capture_cuda_graphs(self):
         n_steps = self.steps_per_segment


### PR DESCRIPTION
## Summary

- Adds an event-based profiler (`EngineProfiler`) that measures per-phase timings of one `engine.step` while CUDA graph capture is active. Two modes selected via `AxionEngineConfig.profiling_mode`: `end_to_end` (coarse: collide / load_data / warm_start_copy / nr_solve / backtracking / output_copy) and `per_component` (per-NR-iteration: linear_system / preconditioner / cr_solve / step_or_linesearch / convergence_check).
- `per_component` replaces `wp.capture_while` in `_solve` with a fixed unroll of `max_newton_iters`. No early exit in this mode, so it tells you per-iter component cost, not production wall-clock.
- `BaseSimulator` brackets the `model.collide` call so the collide phase is counted in `end_to_end`.
- When `profiling_mode="off"` (the default), no events are allocated and no record nodes go into the captured graph — replay cost is unchanged.
- Three new Hydra presets: `engine=axion_profile_e2e`, `engine=axion_profile_per_iter`, `execution=profile` (forces `headless_steps_per_segment=1` so the captured graph contains exactly one `engine.step`; otherwise the unrolled copies overwrite each other's events).

Run a profiling pass with:
```
python examples/ball_fall.py engine=axion_profile_e2e execution=profile rendering=headless
```
Summary table prints automatically at end of `simulator.run()`.

## Test plan

- [x] Smoke test with `engine.step` called directly (no simulator) — `collide` phase gracefully reports `count=0`, all engine-side phases produce sensible numbers.
- [x] Smoke test with `InteractiveSimulator` — `collide` recorded (~0.09 ms on trivial sphere/ground scene), `nr_solve` ~0.17 ms (~50% of step).
- [x] Hydra config composition validated: `axion_profile_e2e` instantiates `AxionEngineConfig` with `profiling_mode='end_to_end'`; `execution=profile` yields `headless_steps_per_segment=1`.
- [x] Manually run `python examples/ball_fall.py engine=axion_profile_e2e execution=profile rendering=headless` and confirm summary printout.
- [ ] Sanity-check `per_component` numbers under a longer run that hits `max_newton_iters` consistently (CR-solver dominance should hold across scenes).