### PR TITLE
Newton solver fixes + contact reduction + convergence tooling

### DIFF
--- a/examples/conf/helhest_benchmark.yaml
+++ b/examples/conf/helhest_benchmark.yaml
@@ -1,0 +1,21 @@
+defaults:
+  - simulation: helhest
+  - rendering: headless
+  - execution: cuda_graph
+  - logging: disabled
+  - engine: axion_profile_per_iter
+  - control: helhest/velocity
+  - _self_
+
+project_name: ${hydra:job.name}
+
+friction_coeff: 0.5
+
+drive_velocity: 5.0
+
+# Benchmark override: profiler events are recorded once per captured graph
+# replay, so we need exactly one engine.step per segment to get per-step
+# stats across the full simulation duration (otherwise only the LAST step
+# in each segment is timed).
+execution:
+  headless_steps_per_segment: 1

--- a/examples/conf/helhest_diagnose.yaml
+++ b/examples/conf/helhest_diagnose.yaml
@@ -1,0 +1,26 @@
+defaults:
+  - simulation: helhest
+  - rendering: headless
+  - execution: cuda_graph
+  - logging: hdf5
+  - engine: axion
+  - control: helhest/velocity
+  - _self_
+
+project_name: ${hydra:job.name}
+
+friction_coeff: 0.5
+
+drive_velocity: 5.0
+
+# One step per captured graph so we can read PCR history between steps.
+execution:
+  headless_steps_per_segment: 1
+
+# Disable HDF5 file write (we read in-memory buffers and dump NPZ ourselves).
+logging:
+  enable_hdf5_logging: true
+  hdf5_log_file: "/tmp/helhest_diagnose_unused.h5"
+
+# NPZ output for the convergence trace
+npz_output: "data/baselines/helhest_pcr_trace.npz"

--- a/examples/conf/helhest_obstacle_benchmark.yaml
+++ b/examples/conf/helhest_obstacle_benchmark.yaml
@@ -1,0 +1,23 @@
+defaults:
+  - simulation: helhest
+  - rendering: headless
+  - execution: cuda_graph
+  - logging: hdf5
+  - engine: axion
+  - control: helhest/velocity
+  - _self_
+
+project_name: ${hydra:job.name}
+
+friction_coeff: 0.5
+
+drive_velocity: 6.0
+
+# Capture per-step PCR + decomposition data for the dashboard / analysis.
+logging:
+  enable_hdf5_logging: true
+  hdf5_log_file: "data/logs/${project_name}.h5"
+
+# One step per captured graph so every step is timed/logged consistently.
+execution:
+  headless_steps_per_segment: 1

--- a/examples/helhest/obstacle_benchmark.py
+++ b/examples/helhest/obstacle_benchmark.py
@@ -1,0 +1,183 @@
+"""Headless deterministic Helhest-vs-obstacles benchmark scene.
+
+Mirrors `obstacle.py` (constant 6.0 rad/s wheel velocity, four static
+box obstacles of increasing height) but in headless mode so the
+workload is reproducible across optimization branches. The robot
+unavoidably impacts an obstacle at some point in the run, which makes
+this scene the natural target for evaluating contact-reduction
+policies (rank-deficiency at impact is exactly the failure mode
+top-K, FPS, cluster, hull are meant to fix).
+"""
+import os
+import pathlib
+from typing import override
+
+import hydra
+import newton
+import numpy as np
+import warp as wp
+from axion import EngineConfig
+from axion import ExecutionConfig
+from axion import InteractiveSimulator
+from axion import LoggingConfig
+from axion import RenderingConfig
+from axion import SimulationConfig
+from omegaconf import DictConfig
+
+try:
+    from examples.helhest.common import create_helhest_model
+except ImportError:
+    from common import create_helhest_model
+
+os.environ["PYOPENGL_PLATFORM"] = "glx"
+
+CONFIG_PATH = pathlib.Path(__file__).parent.parent.joinpath("conf")
+
+
+class HelhestObstacleBenchmark(InteractiveSimulator):
+    """Constant forward drive into a row of static obstacles.
+
+    Velocity-mode control with all three wheels commanded to the same
+    rad/s, so the scene runs deterministically without any keyboard
+    input. ViewerNull rendering keeps it headless and terminates after
+    `simulation.duration_seconds`.
+    """
+
+    def __init__(
+        self,
+        sim_config: SimulationConfig,
+        render_config: RenderingConfig,
+        exec_config: ExecutionConfig,
+        engine_config: EngineConfig,
+        logging_config: LoggingConfig,
+        control_mode: str = "velocity",
+        k_p: float = 150.0,
+        k_d: float = 0.0,
+        friction: float = 0.5,
+        drive_velocity: float = 6.0,
+    ):
+        if control_mode != "velocity":
+            raise ValueError(
+                "obstacle_benchmark only supports control_mode='velocity'; "
+                f"got {control_mode!r}"
+            )
+
+        self.control_mode = control_mode
+        self.k_p = k_p
+        self.k_d = k_d
+        self.friction = friction
+        self.drive_velocity = drive_velocity
+
+        super().__init__(
+            sim_config,
+            render_config,
+            exec_config,
+            engine_config,
+            logging_config,
+        )
+
+        # 9 joint DOFs: 6 free-joint base + 3 wheels (left, right, rear).
+        targets = np.zeros(9, dtype=np.float32)
+        targets[6] = drive_velocity
+        targets[7] = drive_velocity
+        targets[8] = drive_velocity
+        self.joint_target = wp.array(targets, dtype=wp.float32, device=self.model.device)
+
+    @override
+    def init_state_fn(
+        self,
+        current_state: newton.State,
+        next_state: newton.State,
+        contacts: newton.Contacts,
+        dt: float,
+    ):
+        self.solver.integrate_bodies(self.model, current_state, next_state, dt)
+
+    @override
+    def control_policy(self, current_state: newton.State):
+        wp.copy(self.control.joint_target_vel, self.joint_target)
+
+    def build_model(self) -> newton.Model:
+        """Helhest in front of a row of four box obstacles on a ground plane."""
+        self.builder.rigid_gap = 1.0
+
+        robot_x = -1.5
+        robot_y = 0.0
+        robot_z = 0.6
+
+        create_helhest_model(
+            self.builder,
+            xform=wp.transform((robot_x, robot_y, robot_z), wp.quat_identity()),
+            control_mode=self.control_mode,
+            k_p=self.k_p,
+            k_d=self.k_d,
+            friction_left_right=self.friction,
+            friction_rear=self.friction * 0.5,
+        )
+
+        FRICTION = 0.4
+        RESTITUTION = 0.0
+        KE = 1.0e4
+        KD = 1.0e3
+        KF = 1.0e3
+
+        # Four static box obstacles of increasing height in the robot's path.
+        # Heights selected so the robot can clear the first two and impact the
+        # third around step ~60-70 (matches the original obstacle.py scene).
+        for x, hz in [(2.0, 0.10), (5.0, 0.25), (8.0, 0.40), (11.0, 0.65)]:
+            self.builder.add_shape_box(
+                body=-1,
+                xform=wp.transform((x, 0.0, 0.0), wp.quat_identity()),
+                hx=0.5,
+                hy=1.0,
+                hz=hz,
+                cfg=newton.ModelBuilder.ShapeConfig(
+                    mu=FRICTION,
+                    restitution=RESTITUTION,
+                ),
+            )
+
+        self.builder.add_ground_plane(
+            cfg=newton.ModelBuilder.ShapeConfig(
+                ke=KE,
+                kd=KD,
+                kf=KF,
+                mu=FRICTION,
+                restitution=RESTITUTION,
+            )
+        )
+
+        return self.builder.finalize_replicated(
+            num_worlds=self.simulation_config.num_worlds, gravity=-9.81
+        )
+
+
+@hydra.main(
+    config_path=str(CONFIG_PATH),
+    config_name="helhest_obstacle_benchmark",
+    version_base=None,
+)
+def helhest_obstacle_benchmark(cfg: DictConfig):
+    sim_config: SimulationConfig = hydra.utils.instantiate(cfg.simulation)
+    render_config: RenderingConfig = hydra.utils.instantiate(cfg.rendering)
+    exec_config: ExecutionConfig = hydra.utils.instantiate(cfg.execution)
+    engine_config: EngineConfig = hydra.utils.instantiate(cfg.engine)
+    logging_config: LoggingConfig = hydra.utils.instantiate(cfg.logging)
+
+    simulator = HelhestObstacleBenchmark(
+        sim_config,
+        render_config,
+        exec_config,
+        engine_config,
+        logging_config,
+        control_mode=cfg.control.mode,
+        k_p=cfg.control.k_p,
+        k_d=cfg.control.k_d,
+        friction=cfg.friction_coeff,
+        drive_velocity=cfg.drive_velocity,
+    )
+    simulator.run()
+
+
+if __name__ == "__main__":
+    helhest_obstacle_benchmark()

--- a/examples/helhest/surface_drive_benchmark.py
+++ b/examples/helhest/surface_drive_benchmark.py
@@ -1,0 +1,169 @@
+"""Headless, deterministic Helhest-on-surface benchmark scene.
+
+Mirrors `surface_drive.py` but with constant velocity targets and no viewer
+input, so the workload is reproducible across optimization branches. Intended
+to be run with `engine=axion_profile_per_iter` so the per-component profiler
+prints `linear_system / preconditioner / cr_solve / step_or_linesearch /
+convergence_check` timings at the end of the run.
+"""
+import os
+import pathlib
+from typing import override
+
+import hydra
+import newton
+import numpy as np
+import openmesh
+import warp as wp
+from axion import EngineConfig
+from axion import ExecutionConfig
+from axion import InteractiveSimulator
+from axion import LoggingConfig
+from axion import RenderingConfig
+from axion import SimulationConfig
+from omegaconf import DictConfig
+
+try:
+    from examples.helhest.common import create_helhest_model
+except ImportError:
+    from common import create_helhest_model
+
+os.environ["PYOPENGL_PLATFORM"] = "glx"
+
+CONFIG_PATH = pathlib.Path(__file__).parent.parent.joinpath("conf")
+ASSETS_DIR = pathlib.Path(__file__).parent.parent.joinpath("assets")
+
+
+class HelhestSurfaceBenchmark(InteractiveSimulator):
+    """Constant-velocity drive of Helhest across the surface mesh.
+
+    All three wheels are commanded at the same forward velocity, so the robot
+    drives roughly straight. The simulation is fully headless (ViewerNull) and
+    terminates after `simulation.duration_seconds`.
+    """
+
+    def __init__(
+        self,
+        sim_config: SimulationConfig,
+        render_config: RenderingConfig,
+        exec_config: ExecutionConfig,
+        engine_config: EngineConfig,
+        logging_config: LoggingConfig,
+        control_mode: str = "velocity",
+        k_p: float = 150.0,
+        k_d: float = 0.0,
+        friction: float = 0.5,
+        drive_velocity: float = 5.0,
+    ):
+        if control_mode != "velocity":
+            raise ValueError(
+                "surface_drive_benchmark only supports control_mode='velocity'; "
+                f"got {control_mode!r}"
+            )
+
+        self.control_mode = control_mode
+        self.k_p = k_p
+        self.k_d = k_d
+        self.friction = friction
+        self.drive_velocity = drive_velocity
+
+        super().__init__(
+            sim_config,
+            render_config,
+            exec_config,
+            engine_config,
+            logging_config,
+        )
+
+        # 9 joint DOFs: 6 free-joint base + 3 wheels (left, right, rear).
+        targets = np.zeros(9, dtype=np.float32)
+        targets[6] = drive_velocity  # left wheel
+        targets[7] = drive_velocity  # right wheel
+        targets[8] = drive_velocity  # rear wheel
+        self.joint_target = wp.array(targets, dtype=wp.float32, device=self.model.device)
+
+    @override
+    def init_state_fn(
+        self,
+        current_state: newton.State,
+        next_state: newton.State,
+        contacts: newton.Contacts,
+        dt: float,
+    ):
+        self.solver.integrate_bodies(self.model, current_state, next_state, dt)
+
+    @override
+    def control_policy(self, current_state: newton.State):
+        wp.copy(self.control.joint_target_vel, self.joint_target)
+
+    def build_model(self) -> newton.Model:
+        """Helhest on the same surface mesh used by `surface_drive.py`."""
+        self.builder.rigid_gap = 0.5
+
+        robot_x = -1.5
+        robot_y = 0.0
+        robot_z = 1.7
+
+        create_helhest_model(
+            self.builder,
+            xform=wp.transform((robot_x, robot_y, robot_z), wp.quat_identity()),
+            control_mode=self.control_mode,
+            k_p=self.k_p,
+            k_d=self.k_d,
+            friction_left_right=self.friction,
+            friction_rear=self.friction * 0.5,
+        )
+
+        surface_m = openmesh.read_trimesh(str(ASSETS_DIR.joinpath("surface.obj")))
+        mesh_indices = np.array(surface_m.face_vertex_indices(), dtype=np.int32).flatten()
+
+        scale = np.array([6.0, 6.0, 4.0])
+        mesh_points = np.array(surface_m.points()) * scale + np.array([0.0, 0.0, 0.05])
+
+        surface_mesh = newton.Mesh(mesh_points, mesh_indices)
+
+        globals_builder = newton.ModelBuilder()
+        globals_builder.add_shape_mesh(
+            body=-1,
+            mesh=surface_mesh,
+            cfg=newton.ModelBuilder.ShapeConfig(
+                density=0.0,
+                has_shape_collision=True,
+                mu=0.5,
+                ke=150.0,
+                kd=150.0,
+                kf=500.0,
+            ),
+        )
+
+        return self.builder.finalize_replicated(
+            num_worlds=self.simulation_config.num_worlds,
+            global_builder=globals_builder,
+        )
+
+
+@hydra.main(config_path=str(CONFIG_PATH), config_name="helhest_benchmark", version_base=None)
+def helhest_surface_benchmark(cfg: DictConfig):
+    sim_config: SimulationConfig = hydra.utils.instantiate(cfg.simulation)
+    render_config: RenderingConfig = hydra.utils.instantiate(cfg.rendering)
+    exec_config: ExecutionConfig = hydra.utils.instantiate(cfg.execution)
+    engine_config: EngineConfig = hydra.utils.instantiate(cfg.engine)
+    logging_config: LoggingConfig = hydra.utils.instantiate(cfg.logging)
+
+    simulator = HelhestSurfaceBenchmark(
+        sim_config,
+        render_config,
+        exec_config,
+        engine_config,
+        logging_config,
+        control_mode=cfg.control.mode,
+        k_p=cfg.control.k_p,
+        k_d=cfg.control.k_d,
+        friction=cfg.friction_coeff,
+        drive_velocity=cfg.drive_velocity,
+    )
+    simulator.run()
+
+
+if __name__ == "__main__":
+    helhest_surface_benchmark()

--- a/examples/helhest/surface_drive_diagnose.py
+++ b/examples/helhest/surface_drive_diagnose.py
@@ -1,0 +1,271 @@
+"""Diagnostic run: collect PCR convergence traces over many Helhest-on-surface
+steps and dump them to NPZ for pattern analysis.
+
+Subclasses the benchmark scene; the only difference is that after every step
+we copy the engine's per-NR-iter PCR history (iter count + residual decay) to
+host memory, then aggregate and print summary statistics at the end.
+"""
+import os
+import pathlib
+from typing import override
+
+import hydra
+import numpy as np
+import warp as wp
+from omegaconf import DictConfig
+
+try:
+    from examples.helhest.surface_drive_benchmark import HelhestSurfaceBenchmark
+except ImportError:
+    from surface_drive_benchmark import HelhestSurfaceBenchmark
+
+os.environ["PYOPENGL_PLATFORM"] = "glx"
+
+CONFIG_PATH = pathlib.Path(__file__).parent.parent.joinpath("conf")
+
+
+class HelhestSurfaceDiagnose(HelhestSurfaceBenchmark):
+    """Captures PCR per-iter residual histories per step and dumps them."""
+
+    def __init__(self, *args, npz_output: str, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.npz_output = npz_output
+
+        engine = self.solver
+        self.max_newton_iters = engine.config.max_newton_iters
+        self.max_linear_iters = engine.config.max_linear_iters
+        self.num_worlds = engine.dims.num_worlds
+
+        self._iter_counts_per_step = []   # [n_steps, max_newton_iters]
+        self._residuals_per_step = []     # [n_steps, max_newton_iters, max_linear_iters+1, num_worlds]
+        self._nr_iters_per_step = []      # [n_steps]
+        self._nr_res_norm_sq_per_step = []  # [n_steps, max_newton_iters, num_worlds]
+
+    @override
+    def _run_segment_with_graph(self, segment_num: int):
+        super()._run_segment_with_graph(segment_num)
+        self._capture_step_history()
+
+    @override
+    def _run_segment_without_graph(self, segment_num: int):
+        super()._run_segment_without_graph(segment_num)
+        self._capture_step_history()
+
+    def _capture_step_history(self):
+        engine = self.solver
+        data = engine.data
+
+        # Force the device to finish before we read the history buffers.
+        wp.synchronize_device(self.model.device)
+
+        nr_iters = int(data.iter_count.numpy()[0])
+        iter_counts = data.pcr_history_iter_count.numpy().reshape(self.max_newton_iters)
+        residuals = data.pcr_history_res_norm_sq_history.numpy().copy()
+        # Newton residual norm at each NR-iter (post-step). Shape (K, W).
+        nr_res = data.candidates_res_norm_sq.numpy().copy()
+
+        self._nr_iters_per_step.append(nr_iters)
+        self._iter_counts_per_step.append(iter_counts)
+        self._residuals_per_step.append(residuals)
+        self._nr_res_norm_sq_per_step.append(nr_res)
+
+    def run(self):
+        try:
+            super().run()
+        finally:
+            self._dump_and_summarize()
+
+    def _dump_and_summarize(self):
+        if not self._iter_counts_per_step:
+            print("[diagnose] no steps captured; nothing to dump.")
+            return
+
+        nr_iters = np.asarray(self._nr_iters_per_step, dtype=np.int32)
+        iter_counts = np.stack(self._iter_counts_per_step)         # (S, K)
+        residuals = np.stack(self._residuals_per_step)             # (S, K, L+1, W)
+        nr_res = np.stack(self._nr_res_norm_sq_per_step)           # (S, K, W)
+
+        os.makedirs(os.path.dirname(self.npz_output) or ".", exist_ok=True)
+        np.savez(
+            self.npz_output,
+            nr_iters=nr_iters,
+            pcr_iter_counts=iter_counts,
+            pcr_residual_sq_history=residuals,
+            nr_res_norm_sq=nr_res,
+            max_newton_iters=self.max_newton_iters,
+            max_linear_iters=self.max_linear_iters,
+            num_worlds=self.num_worlds,
+        )
+        print(f"\n[diagnose] dumped trace to {self.npz_output}")
+        self._print_summary(nr_iters, iter_counts, residuals, nr_res)
+
+    def _print_summary(self, nr_iters, iter_counts, residuals, nr_res):
+        max_K = self.max_newton_iters
+        max_L = self.max_linear_iters
+        n_steps = iter_counts.shape[0]
+
+        # Build a (step, nr_iter) mask that excludes NR iters that didn't run.
+        idx = np.arange(max_K)[None, :]
+        ran_mask = idx < nr_iters[:, None]    # (S, K)
+
+        flat_iters = iter_counts[ran_mask]
+        total_pcr = int(flat_iters.sum())
+        n_pairs = int(ran_mask.sum())
+
+        print("=" * 72)
+        print(f"[diagnose] {n_steps} steps, {n_pairs} (step, NR-iter) pairs")
+        print("-" * 72)
+
+        # 1. Newton iter count distribution
+        nr_max = int(nr_iters.max())
+        nr_min = int(nr_iters.min())
+        nr_mean = float(nr_iters.mean())
+        print(f"NR iters per step    min={nr_min}  mean={nr_mean:.2f}  max={nr_max}")
+        nr_hit_max = int((nr_iters >= max_K).sum())
+        print(f"NR-iters hit max ({max_K}): {nr_hit_max}/{n_steps} steps  "
+              f"({100*nr_hit_max/n_steps:.1f}%)")
+
+        # 2. PCR iter count distribution across all (step, NR-iter) pairs
+        pcr_min = int(flat_iters.min())
+        pcr_max = int(flat_iters.max())
+        pcr_mean = float(flat_iters.mean())
+        pcr_p50 = float(np.percentile(flat_iters, 50))
+        pcr_p95 = float(np.percentile(flat_iters, 95))
+        print(f"PCR iters per NR-it  min={pcr_min}  mean={pcr_mean:.2f}  "
+              f"p50={pcr_p50:.0f}  p95={pcr_p95:.0f}  max={pcr_max}")
+
+        pcr_hit_max = int((flat_iters >= max_L).sum())
+        print(f"PCR hit max ({max_L}): {pcr_hit_max}/{n_pairs} solves  "
+              f"({100*pcr_hit_max/n_pairs:.1f}%)")
+
+        bins = np.bincount(flat_iters.astype(np.int64), minlength=max_L + 2)
+        print("PCR iter histogram   |", end="")
+        for k, c in enumerate(bins):
+            if c == 0:
+                continue
+            print(f" {k}:{c}", end="")
+        print()
+
+        # 3. Per-NR-iter median PCR iter count (does early NR cost more?)
+        per_nr_med = []
+        per_nr_mean = []
+        for k in range(max_K):
+            col = iter_counts[ran_mask[:, k], k]
+            if col.size:
+                per_nr_med.append(int(np.median(col)))
+                per_nr_mean.append(float(col.mean()))
+            else:
+                per_nr_med.append(-1)
+                per_nr_mean.append(float("nan"))
+        print(f"PCR iters by NR-iter (median): {per_nr_med}")
+        # Show first few and last few means with 2 decimals
+        head = ", ".join(f"{v:.2f}" for v in per_nr_mean[:6])
+        tail = ", ".join(f"{v:.2f}" for v in per_nr_mean[-6:])
+        print(f"PCR iters by NR-iter (mean):   [{head}, ..., {tail}]")
+
+        # 4. Convergence quality: log-residual drop per iter, averaged over solves
+        # residuals[s, k, ell, w] = r²; iter count for (s,k) is iter_counts[s,k].
+        # We compute, for each (s,k) with ran_mask, the log10(r²[ell] / r²[0])
+        # at ell = 1, 4, 8, max_L.
+        eps = 1e-30
+        log_drops = {1: [], 4: [], 8: [], max_L: []}
+        plateau_count = 0
+        plateau_threshold = 0.05  # less than ~10% drop in last 4 iters → plateau
+
+        for s in range(n_steps):
+            for k in range(int(nr_iters[s])):
+                hist = residuals[s, k, :, 0]  # only world 0
+                count = int(iter_counts[s, k])
+                if count <= 1:
+                    continue
+                r0 = hist[0] + eps
+                for ell in log_drops:
+                    if ell <= count:
+                        log_drops[ell].append(np.log10((hist[ell] + eps) / r0))
+                # Plateau detection: in the last 4 iters before stop, did r²
+                # drop by less than `plateau_threshold` decades?
+                if count >= 5:
+                    last_drop = np.log10((hist[count] + eps) / (hist[count - 4] + eps))
+                    if abs(last_drop) < plateau_threshold:
+                        plateau_count += 1
+
+        print("-" * 72)
+        print("Residual decay (log10 r²[ell] / r²[0], world 0):")
+        for ell in sorted(log_drops):
+            arr = np.asarray(log_drops[ell]) if log_drops[ell] else np.zeros(0)
+            if arr.size:
+                print(f"  iter={ell:>3}: mean={arr.mean():+.2f}  "
+                      f"p50={np.percentile(arr, 50):+.2f}  "
+                      f"p95={np.percentile(arr, 95):+.2f}  n={arr.size}")
+            else:
+                print(f"  iter={ell:>3}: (no solves ran this many iters)")
+        print(f"Plateau (last 4 iters drop < {plateau_threshold} decades): "
+              f"{plateau_count}/{n_pairs} solves "
+              f"({100*plateau_count/max(n_pairs,1):.1f}%)")
+
+        # 5. Newton residual progression: are we close to atol or far?
+        # nr_res[s, k, w] = ||r||² at the candidate stored after NR iter k.
+        # An "always max iters" symptom only matters if the final residual
+        # is well above atol². Show the final residual of each step (world 0).
+        eps_nr = 1e-30
+        print("-" * 72)
+        final_nr = np.array(
+            [nr_res[s, int(nr_iters[s]) - 1, 0] for s in range(n_steps)]
+        )
+        log10_final = np.log10(final_nr + eps_nr)
+        print(f"NR final ||r||² (world 0):  "
+              f"min={final_nr.min():.2e}  "
+              f"p50={np.percentile(final_nr, 50):.2e}  "
+              f"p95={np.percentile(final_nr, 95):.2e}  "
+              f"max={final_nr.max():.2e}")
+        print(f"NR final log10||r||²:       "
+              f"min={log10_final.min():+.2f}  "
+              f"p50={np.percentile(log10_final, 50):+.2f}  "
+              f"p95={np.percentile(log10_final, 95):+.2f}  "
+              f"max={log10_final.max():+.2f}")
+        # Per-NR-iter median of log10 ||r||² across steps (world 0).
+        per_nr_log = []
+        for k in range(max_K):
+            col = nr_res[ran_mask[:, k], k, 0]
+            if col.size:
+                per_nr_log.append(float(np.log10(np.median(col) + eps_nr)))
+            else:
+                per_nr_log.append(float("nan"))
+        head = ", ".join(f"{v:+.2f}" for v in per_nr_log[:8])
+        tail = ", ".join(f"{v:+.2f}" for v in per_nr_log[-8:])
+        print(f"NR log10||r||² by iter median: [{head}, ..., {tail}]")
+        print("=" * 72)
+
+
+@hydra.main(config_path=str(CONFIG_PATH), config_name="helhest_diagnose", version_base=None)
+def helhest_surface_diagnose(cfg: DictConfig):
+    from axion import EngineConfig
+    from axion import ExecutionConfig
+    from axion import LoggingConfig
+    from axion import RenderingConfig
+    from axion import SimulationConfig
+
+    sim_config: SimulationConfig = hydra.utils.instantiate(cfg.simulation)
+    render_config: RenderingConfig = hydra.utils.instantiate(cfg.rendering)
+    exec_config: ExecutionConfig = hydra.utils.instantiate(cfg.execution)
+    engine_config: EngineConfig = hydra.utils.instantiate(cfg.engine)
+    logging_config: LoggingConfig = hydra.utils.instantiate(cfg.logging)
+
+    simulator = HelhestSurfaceDiagnose(
+        sim_config,
+        render_config,
+        exec_config,
+        engine_config,
+        logging_config,
+        control_mode=cfg.control.mode,
+        k_p=cfg.control.k_p,
+        k_d=cfg.control.k_d,
+        friction=cfg.friction_coeff,
+        drive_velocity=cfg.drive_velocity,
+        npz_output=cfg.npz_output,
+    )
+    simulator.run()
+
+
+if __name__ == "__main__":
+    helhest_surface_diagnose()

--- a/src/axion/collision/__init__.py
+++ b/src/axion/collision/__init__.py
@@ -1,0 +1,50 @@
+"""Contact-pipeline preprocessing.
+
+This subpackage sits between Newton's narrow-phase output and Axion's
+constraint kernels. Today it provides per-pair contact reduction policies;
+in the future it can host other contact-pipeline preprocessing (warm
+starting, contact-graph analysis, etc.).
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import ContactReducer, NoOpReducer
+from .config import ContactReductionConfig, ContactReductionPolicy
+
+if TYPE_CHECKING:
+    from axion.core.engine_dims import EngineDimensions
+    import warp as wp
+
+
+def build_reducer(
+    cfg: ContactReductionConfig,
+    dims: "EngineDimensions",
+    device: "wp.Device",
+) -> ContactReducer:
+    """Construct a reducer instance from a config.
+
+    Args:
+        cfg: User-provided reduction settings. ``cfg.policy="none"``
+            yields a no-op reducer.
+        dims: Engine dimensions (for kernels that allocate per-world
+            scratch buffers).
+        device: Warp device that the reducer's kernels will launch on.
+    """
+    policy = cfg.policy
+    if policy == "none":
+        return NoOpReducer()
+    raise NotImplementedError(
+        f"Contact reduction policy {policy!r} is not implemented yet. "
+        "Phase 0 ships only the no-op path; subsequent phases add "
+        "'top_k', 'fps', 'cluster', and 'hull'."
+    )
+
+
+__all__ = [
+    "ContactReducer",
+    "NoOpReducer",
+    "ContactReductionConfig",
+    "ContactReductionPolicy",
+    "build_reducer",
+]

--- a/src/axion/collision/__init__.py
+++ b/src/axion/collision/__init__.py
@@ -49,9 +49,13 @@ def build_reducer(
         from .fps import FPSReducer
 
         return FPSReducer(cfg, axion_model, data, dims, device)
+    if policy == "cluster":
+        from .cluster import ClusterReducer
+
+        return ClusterReducer(cfg, axion_model, data, dims, device)
     raise NotImplementedError(
         f"Contact reduction policy {policy!r} is not implemented yet. "
-        "Subsequent phases add 'cluster' and 'hull'."
+        "Subsequent phases add 'hull'."
     )
 
 

--- a/src/axion/collision/__init__.py
+++ b/src/axion/collision/__init__.py
@@ -13,12 +13,16 @@ from .base import ContactReducer, NoOpReducer
 from .config import ContactReductionConfig, ContactReductionPolicy
 
 if TYPE_CHECKING:
+    from axion.core.engine_data import EngineData
     from axion.core.engine_dims import EngineDimensions
+    from axion.core.model import AxionModel
     import warp as wp
 
 
 def build_reducer(
     cfg: ContactReductionConfig,
+    axion_model: "AxionModel",
+    data: "EngineData",
     dims: "EngineDimensions",
     device: "wp.Device",
 ) -> ContactReducer:
@@ -27,17 +31,23 @@ def build_reducer(
     Args:
         cfg: User-provided reduction settings. ``cfg.policy="none"``
             yields a no-op reducer.
-        dims: Engine dimensions (for kernels that allocate per-world
-            scratch buffers).
-        device: Warp device that the reducer's kernels will launch on.
+        axion_model: Source of ``shape_body`` (per-world shape→body table).
+        data: Source of ``body_pose_prev`` (current step's body pose,
+            updated by ``load_data`` before reduction runs).
+        dims: Engine dimensions; reducers allocate persistent
+            ``(num_worlds, contact_count)`` scratch buffers from these.
+        device: Warp device for kernel launches and scratch allocation.
     """
     policy = cfg.policy
     if policy == "none":
         return NoOpReducer()
+    if policy == "top_k":
+        from .top_k import TopKReducer
+
+        return TopKReducer(cfg, axion_model, data, dims, device)
     raise NotImplementedError(
         f"Contact reduction policy {policy!r} is not implemented yet. "
-        "Phase 0 ships only the no-op path; subsequent phases add "
-        "'top_k', 'fps', 'cluster', and 'hull'."
+        "Subsequent phases add 'fps', 'cluster', and 'hull'."
     )
 
 

--- a/src/axion/collision/__init__.py
+++ b/src/axion/collision/__init__.py
@@ -45,9 +45,13 @@ def build_reducer(
         from .top_k import TopKReducer
 
         return TopKReducer(cfg, axion_model, data, dims, device)
+    if policy == "fps":
+        from .fps import FPSReducer
+
+        return FPSReducer(cfg, axion_model, data, dims, device)
     raise NotImplementedError(
         f"Contact reduction policy {policy!r} is not implemented yet. "
-        "Subsequent phases add 'fps', 'cluster', and 'hull'."
+        "Subsequent phases add 'cluster' and 'hull'."
     )
 
 

--- a/src/axion/collision/base.py
+++ b/src/axion/collision/base.py
@@ -1,0 +1,39 @@
+"""Abstract base class for contact reducers and a no-op default."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from axion.core.contacts import AxionContacts
+
+
+class ContactReducer(ABC):
+    """In-place contact reducer.
+
+    A reducer compacts the active contact list inside an ``AxionContacts``
+    instance so that, for each (body0, body1) pair, at most a configured
+    number of contacts survive. Survivors are placed at the front of the
+    per-world contact arrays and ``contact_count[w]`` is decreased to the
+    survivor count, so downstream constraint kernels (which gate on
+    ``c_idx >= contact_count[w]``) see the reduced set without any
+    further changes.
+
+    Implementations must be CUDA-graph capture safe: kernel launch
+    dimensions and memory addresses cannot depend on host-side decisions
+    that change between captures.
+    """
+
+    @abstractmethod
+    def apply(self, contacts: "AxionContacts") -> None:
+        """Reduce contacts in place. Called once per simulation step,
+        after ``AxionContacts.load_contact_data`` and before the engine
+        builds the linear system for that step."""
+        raise NotImplementedError
+
+
+class NoOpReducer(ContactReducer):
+    """Reducer that does nothing — preserves pre-module engine behavior."""
+
+    def apply(self, contacts: "AxionContacts") -> None:  # noqa: D401
+        return

--- a/src/axion/collision/cluster.py
+++ b/src/axion/collision/cluster.py
@@ -1,0 +1,333 @@
+"""Cluster-based contact reducer.
+
+For each (body0, body1) pair, contacts are clustered by a "near-duplicate"
+criterion: two contacts agree if their normals are within an angular
+threshold AND their midpoints are within a distance threshold. The
+representative of each cluster is its deepest contact; among
+representatives, the K with the largest depth survive.
+
+Compared to FPS, cluster reduction has different goals:
+  - FPS *spreads* survivors maximally across the contact patch.
+  - Cluster reduction *removes only true duplicates*; if the original
+    contacts are already well-spread, clustering is a near-no-op.
+
+The two policies trade off coverage vs. fidelity. For our obstacle
+scene, a wheel sitting flat on a box has many near-coplanar contact
+points whose normals all point straight up and whose midpoints are
+within a few mm; cluster reduction collapses those to one.
+
+Implementation:
+  Pass 1 (per pair, single-threaded by the leader):
+      For each contact j in the pair, j is a "representative" iff no
+      deeper contact in the same pair matches it (normal-dot > thresh
+      AND midpoint-distance < thresh). The match relation is non-
+      transitive in general, but using "no deeper match" yields the
+      max element of each connected component under the dominance
+      relation, which is what we want.
+
+  Pass 2 (same leader):
+      Among representatives, compute rank by depth (descending).
+      Keep contacts with rank < K.
+
+Both passes are O(N_pair²) inside a single leader thread, so total
+cost per pair is bounded by ~225 contact comparisons for our scenes.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import warp as wp
+
+from .base import ContactReducer
+from .config import ContactReductionConfig
+from .fps import scatter_by_keep_kernel
+
+if TYPE_CHECKING:
+    from axion.core.contacts import AxionContacts
+    from axion.core.engine_data import EngineData
+    from axion.core.engine_dims import EngineDimensions
+    from axion.core.model import AxionModel
+
+
+@wp.func
+def _resolve_body(world_idx: int, shape_idx: int,
+                  shape_body: wp.array(dtype=wp.int32, ndim=2)) -> int:
+    if shape_idx < 0:
+        return -1
+    return shape_body[world_idx, shape_idx]
+
+
+@wp.func
+def _depth_and_midpoint(
+    world_idx: int,
+    c_idx: int,
+    contact_point0: wp.array(dtype=wp.vec3, ndim=2),
+    contact_point1: wp.array(dtype=wp.vec3, ndim=2),
+    contact_normal: wp.array(dtype=wp.vec3, ndim=2),
+    contact_thickness0: wp.array(dtype=wp.float32, ndim=2),
+    contact_thickness1: wp.array(dtype=wp.float32, ndim=2),
+    body_a: int,
+    body_b: int,
+    body_pose: wp.array(dtype=wp.transform, ndim=2),
+):
+    n = contact_normal[world_idx, c_idx]
+    p_a_local = contact_point0[world_idx, c_idx]
+    p_b_local = contact_point1[world_idx, c_idx]
+    t_a = contact_thickness0[world_idx, c_idx]
+    t_b = contact_thickness1[world_idx, c_idx]
+
+    pose_a = wp.transform_identity()
+    if body_a >= 0:
+        pose_a = body_pose[world_idx, body_a]
+    pose_b = wp.transform_identity()
+    if body_b >= 0:
+        pose_b = body_pose[world_idx, body_b]
+
+    p_a_world = wp.transform_point(pose_a, p_a_local) - t_a * n
+    p_b_world = wp.transform_point(pose_b, p_b_local) + t_b * n
+
+    depth = wp.dot(n, p_b_world - p_a_world)
+    midpoint = 0.5 * (p_a_world + p_b_world)
+    return depth, midpoint
+
+
+@wp.kernel
+def cluster_per_pair_kernel(
+    contact_count: wp.array(dtype=wp.int32, ndim=1),
+    contact_point0: wp.array(dtype=wp.vec3, ndim=2),
+    contact_point1: wp.array(dtype=wp.vec3, ndim=2),
+    contact_normal: wp.array(dtype=wp.vec3, ndim=2),
+    contact_shape0: wp.array(dtype=wp.int32, ndim=2),
+    contact_shape1: wp.array(dtype=wp.int32, ndim=2),
+    contact_thickness0: wp.array(dtype=wp.float32, ndim=2),
+    contact_thickness1: wp.array(dtype=wp.float32, ndim=2),
+    shape_body: wp.array(dtype=wp.int32, ndim=2),
+    body_pose: wp.array(dtype=wp.transform, ndim=2),
+    K: wp.int32,
+    normal_dot_thresh: wp.float32,
+    pos_thresh: wp.float32,
+    keep_mask: wp.array(dtype=wp.int32, ndim=2),
+):
+    """One thread per (world, c_idx). The pair-leader thread (smallest
+    c_idx with this (b0, b1)) runs both passes serially and writes to
+    keep-mask cells of contacts in its pair only — disjoint across
+    leaders."""
+    world_idx, c_idx = wp.tid()
+    n_count = contact_count[world_idx]
+    if c_idx >= n_count:
+        return
+
+    s0 = contact_shape0[world_idx, c_idx]
+    s1 = contact_shape1[world_idx, c_idx]
+    if s0 == s1:
+        return
+
+    b0 = _resolve_body(world_idx, s0, shape_body)
+    b1 = _resolve_body(world_idx, s1, shape_body)
+
+    is_leader = wp.bool(True)
+    for j in range(c_idx):
+        sj0 = contact_shape0[world_idx, j]
+        sj1 = contact_shape1[world_idx, j]
+        if sj0 == sj1:
+            continue
+        bj0 = _resolve_body(world_idx, sj0, shape_body)
+        bj1 = _resolve_body(world_idx, sj1, shape_body)
+        if bj0 == b0 and bj1 == b1:
+            is_leader = wp.bool(False)
+    if not is_leader:
+        return
+
+    pos_thresh_sq = pos_thresh * pos_thresh
+
+    # Pass 1: mark representatives. j is a rep iff no deeper contact in
+    # the same pair matches it. We use keep_mask as scratch first
+    # (1 = rep, 0 = not), then overwrite in pass 2.
+    for j in range(n_count):
+        sj0 = contact_shape0[world_idx, j]
+        sj1 = contact_shape1[world_idx, j]
+        if sj0 == sj1:
+            continue
+        bj0 = _resolve_body(world_idx, sj0, shape_body)
+        bj1 = _resolve_body(world_idx, sj1, shape_body)
+        if bj0 != b0 or bj1 != b1:
+            continue
+
+        nj = contact_normal[world_idx, j]
+        depth_j, mp_j = _depth_and_midpoint(
+            world_idx, j,
+            contact_point0, contact_point1, contact_normal,
+            contact_thickness0, contact_thickness1,
+            bj0, bj1, body_pose,
+        )
+
+        is_rep = wp.bool(True)
+        for k in range(n_count):
+            if k == j:
+                continue
+            sk0 = contact_shape0[world_idx, k]
+            sk1 = contact_shape1[world_idx, k]
+            if sk0 == sk1:
+                continue
+            bk0 = _resolve_body(world_idx, sk0, shape_body)
+            bk1 = _resolve_body(world_idx, sk1, shape_body)
+            if bk0 != b0 or bk1 != b1:
+                continue
+            nk = contact_normal[world_idx, k]
+            depth_k, mp_k = _depth_and_midpoint(
+                world_idx, k,
+                contact_point0, contact_point1, contact_normal,
+                contact_thickness0, contact_thickness1,
+                bk0, bk1, body_pose,
+            )
+            n_dot = wp.dot(nj, nk)
+            mp_dist_sq = wp.length_sq(mp_j - mp_k)
+            if n_dot > normal_dot_thresh and mp_dist_sq < pos_thresh_sq:
+                # k is in same cluster as j. Is k deeper?
+                if depth_k > depth_j or (depth_k == depth_j and k < j):
+                    is_rep = wp.bool(False)
+
+        if is_rep:
+            keep_mask[world_idx, j] = 1
+        else:
+            keep_mask[world_idx, j] = 0
+
+    # Pass 2: among representatives, rank by depth and keep top K.
+    # We do this in-place on keep_mask: for each rep, count deeper reps
+    # in the same pair; if rank >= K, drop the keep flag.
+    for j in range(n_count):
+        if keep_mask[world_idx, j] != 1:
+            continue
+        sj0 = contact_shape0[world_idx, j]
+        sj1 = contact_shape1[world_idx, j]
+        bj0 = _resolve_body(world_idx, sj0, shape_body)
+        bj1 = _resolve_body(world_idx, sj1, shape_body)
+
+        depth_j, _mp_unused_j = _depth_and_midpoint(
+            world_idx, j,
+            contact_point0, contact_point1, contact_normal,
+            contact_thickness0, contact_thickness1,
+            bj0, bj1, body_pose,
+        )
+
+        rank = wp.int32(0)
+        for k in range(n_count):
+            if k == j:
+                continue
+            if keep_mask[world_idx, k] != 1:
+                continue
+            sk0 = contact_shape0[world_idx, k]
+            sk1 = contact_shape1[world_idx, k]
+            bk0 = _resolve_body(world_idx, sk0, shape_body)
+            bk1 = _resolve_body(world_idx, sk1, shape_body)
+            if bk0 != b0 or bk1 != b1:
+                continue
+            depth_k, _mp_unused_k = _depth_and_midpoint(
+                world_idx, k,
+                contact_point0, contact_point1, contact_normal,
+                contact_thickness0, contact_thickness1,
+                bk0, bk1, body_pose,
+            )
+            if depth_k > depth_j or (depth_k == depth_j and k < j):
+                rank += 1
+
+        if rank >= K:
+            keep_mask[world_idx, j] = 0
+
+
+class ClusterReducer(ContactReducer):
+    """Cluster-then-keep-top-K-deepest-cluster-rep contact reduction."""
+
+    def __init__(
+        self,
+        cfg: ContactReductionConfig,
+        axion_model: "AxionModel",
+        data: "EngineData",
+        dims: "EngineDimensions",
+        device: wp.Device,
+    ):
+        self._K = int(cfg.max_per_pair)
+        self._normal_dot_thresh = float(cfg.cluster_normal_dot_thresh)
+        self._pos_thresh = float(cfg.cluster_pos_thresh)
+        self._device = device
+        self._shape_body = axion_model.shape_body
+        self._body_pose = data.body_pose_prev
+
+        N_w = dims.num_worlds
+        N_c = dims.contact_count
+
+        with wp.ScopedDevice(device):
+            self._keep_mask = wp.zeros((N_w, N_c), dtype=wp.int32)
+            self._new_count = wp.zeros((N_w,), dtype=wp.int32)
+            self._scratch_point0 = wp.zeros((N_w, N_c), dtype=wp.vec3)
+            self._scratch_point1 = wp.zeros((N_w, N_c), dtype=wp.vec3)
+            self._scratch_normal = wp.zeros((N_w, N_c), dtype=wp.vec3)
+            self._scratch_shape0 = wp.zeros((N_w, N_c), dtype=wp.int32)
+            self._scratch_shape1 = wp.zeros((N_w, N_c), dtype=wp.int32)
+            self._scratch_thickness0 = wp.zeros((N_w, N_c), dtype=wp.float32)
+            self._scratch_thickness1 = wp.zeros((N_w, N_c), dtype=wp.float32)
+
+    def apply(self, contacts: "AxionContacts") -> None:
+        N_w = contacts.num_worlds
+        N_c = contacts.max_contacts
+
+        self._keep_mask.zero_()
+
+        wp.launch(
+            kernel=cluster_per_pair_kernel,
+            dim=(N_w, N_c),
+            inputs=[
+                contacts.contact_count,
+                contacts.contact_point0,
+                contacts.contact_point1,
+                contacts.contact_normal,
+                contacts.contact_shape0,
+                contacts.contact_shape1,
+                contacts.contact_thickness0,
+                contacts.contact_thickness1,
+                self._shape_body,
+                self._body_pose,
+                self._K,
+                self._normal_dot_thresh,
+                self._pos_thresh,
+            ],
+            outputs=[self._keep_mask],
+            device=self._device,
+        )
+
+        self._new_count.zero_()
+        wp.launch(
+            kernel=scatter_by_keep_kernel,
+            dim=(N_w, N_c),
+            inputs=[
+                self._keep_mask,
+                contacts.contact_count,
+                contacts.contact_point0,
+                contacts.contact_point1,
+                contacts.contact_normal,
+                contacts.contact_shape0,
+                contacts.contact_shape1,
+                contacts.contact_thickness0,
+                contacts.contact_thickness1,
+            ],
+            outputs=[
+                self._new_count,
+                self._scratch_point0,
+                self._scratch_point1,
+                self._scratch_normal,
+                self._scratch_shape0,
+                self._scratch_shape1,
+                self._scratch_thickness0,
+                self._scratch_thickness1,
+            ],
+            device=self._device,
+        )
+
+        wp.copy(contacts.contact_count, self._new_count)
+        wp.copy(contacts.contact_point0, self._scratch_point0)
+        wp.copy(contacts.contact_point1, self._scratch_point1)
+        wp.copy(contacts.contact_normal, self._scratch_normal)
+        wp.copy(contacts.contact_shape0, self._scratch_shape0)
+        wp.copy(contacts.contact_shape1, self._scratch_shape1)
+        wp.copy(contacts.contact_thickness0, self._scratch_thickness0)
+        wp.copy(contacts.contact_thickness1, self._scratch_thickness1)

--- a/src/axion/collision/config.py
+++ b/src/axion/collision/config.py
@@ -1,0 +1,59 @@
+"""Configuration for contact reduction policies.
+
+The reducer runs once per simulation step, between Newton's narrow-phase
+output and the construction of the constraint linear system. It groups
+active contacts by the (body0, body1) pair they touch and prunes the set
+to at most ``max_per_pair`` representatives per pair.
+"""
+from dataclasses import dataclass
+from typing import Literal
+
+
+ContactReductionPolicy = Literal["none", "top_k", "fps", "cluster", "hull"]
+
+
+@dataclass(frozen=True)
+class ContactReductionConfig:
+    """Per-pair contact reduction settings.
+
+    Attributes:
+        policy: Reduction strategy.
+            - ``"none"``: pass-through (no reduction); the engine behaves as
+              before this module existed.
+            - ``"top_k"``: keep the K deepest contacts per (b0, b1) pair.
+            - ``"fps"``: greedy farthest-point sampling per pair, seeded
+              with the deepest contact.
+            - ``"cluster"``: collapse contacts whose normals and positions
+              agree within thresholds; keep the deepest member of each
+              cluster, up to K clusters.
+            - ``"hull"``: 2D convex hull on the contact plane, keep
+              boundary points, up to K.
+        max_per_pair: K — upper bound on contacts kept per (b0, b1) pair.
+            Ignored when ``policy="none"``. K=4 matches Bullet's default.
+        cluster_normal_dot_thresh: Two contact normals are considered
+            "the same direction" when their dot product exceeds this value
+            (~0.996 ≈ 5°). Only consumed by ``policy="cluster"``.
+        cluster_pos_thresh: World-space distance below which two contacts
+            on the same body pair are considered the "same point" [m].
+            Only consumed by ``policy="cluster"``.
+    """
+
+    policy: ContactReductionPolicy = "none"
+    max_per_pair: int = 4
+    cluster_normal_dot_thresh: float = 0.996
+    cluster_pos_thresh: float = 5e-3
+
+    def __post_init__(self) -> None:
+        if self.max_per_pair < 1:
+            raise ValueError(
+                f"max_per_pair must be >= 1, got {self.max_per_pair}"
+            )
+        if not (-1.0 <= self.cluster_normal_dot_thresh <= 1.0):
+            raise ValueError(
+                f"cluster_normal_dot_thresh must be in [-1, 1], "
+                f"got {self.cluster_normal_dot_thresh}"
+            )
+        if self.cluster_pos_thresh < 0.0:
+            raise ValueError(
+                f"cluster_pos_thresh must be >= 0, got {self.cluster_pos_thresh}"
+            )

--- a/src/axion/collision/config.py
+++ b/src/axion/collision/config.py
@@ -5,7 +5,7 @@ output and the construction of the constraint linear system. It groups
 active contacts by the (body0, body1) pair they touch and prunes the set
 to at most ``max_per_pair`` representatives per pair.
 """
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from typing import Literal
 
 
@@ -57,3 +57,20 @@ class ContactReductionConfig:
             raise ValueError(
                 f"cluster_pos_thresh must be >= 0, got {self.cluster_pos_thresh}"
             )
+
+    @classmethod
+    def coerce(cls, obj) -> "ContactReductionConfig":
+        """Best-effort conversion from a dict-like object (e.g. a Hydra
+        ``DictConfig`` left in place by partial overrides) into a real
+        ``ContactReductionConfig`` with proper defaults filled in.
+
+        Already-instantiated configs are returned unchanged.
+        """
+        if isinstance(obj, cls):
+            return obj
+        try:
+            items = dict(obj)
+        except Exception:
+            return cls()
+        valid = {f.name for f in fields(cls)}
+        return cls(**{k: v for k, v in items.items() if k in valid})

--- a/src/axion/collision/fps.py
+++ b/src/axion/collision/fps.py
@@ -1,0 +1,356 @@
+"""Greedy farthest-point-sampling contact reducer.
+
+For each (body0, body1) pair, picks K contacts:
+  1. Seed: the deepest contact in the pair.
+  2. Iteratively pick the contact whose minimum 3D distance to any
+     already-picked contact in the pair is maximal.
+
+This is the classic FPS pattern. Compared to ``top_k`` it spreads
+survivors across the contact patch instead of keeping only the
+deepest cluster, which usually produces a more "tetrahedral" support
+polygon — the structure stable contact relies on.
+
+Implementation detail: per-pair work is serialized inside one thread
+(the "pair leader" — the smallest c_idx in the pair). Threads from
+different pairs run in parallel and write to disjoint cells of a
+keep-mask, so there is no race even though the leader emits multiple
+writes for its pair. K is a runtime int — the inner loops use
+runtime bounds, which Warp accepts for plain ``for ... in range(...)``.
+
+The compaction step (move kept contacts to the front, decrement
+``contact_count``) follows the same pattern as ``top_k.py``: an
+atomic-counter scatter into per-reducer scratch buffers, then 8
+``wp.copy``s back into ``AxionContacts``.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import warp as wp
+
+from .base import ContactReducer
+from .config import ContactReductionConfig
+
+if TYPE_CHECKING:
+    from axion.core.contacts import AxionContacts
+    from axion.core.engine_data import EngineData
+    from axion.core.engine_dims import EngineDimensions
+    from axion.core.model import AxionModel
+
+
+@wp.func
+def _resolve_body(world_idx: int, shape_idx: int,
+                  shape_body: wp.array(dtype=wp.int32, ndim=2)) -> int:
+    if shape_idx < 0:
+        return -1
+    return shape_body[world_idx, shape_idx]
+
+
+@wp.func
+def _depth_and_midpoint(
+    world_idx: int,
+    c_idx: int,
+    contact_point0: wp.array(dtype=wp.vec3, ndim=2),
+    contact_point1: wp.array(dtype=wp.vec3, ndim=2),
+    contact_normal: wp.array(dtype=wp.vec3, ndim=2),
+    contact_thickness0: wp.array(dtype=wp.float32, ndim=2),
+    contact_thickness1: wp.array(dtype=wp.float32, ndim=2),
+    body_a: int,
+    body_b: int,
+    body_pose: wp.array(dtype=wp.transform, ndim=2),
+):
+    """Return ``(depth, midpoint_world)`` for one contact.
+
+    Depth: ``dot(n, p_b_world − p_a_world)`` after thickness offsets;
+    positive when penetrating. Midpoint: 0.5 * (p_a_world + p_b_world)
+    after the same offsets — used as the FPS distance metric.
+    """
+    n = contact_normal[world_idx, c_idx]
+    p_a_local = contact_point0[world_idx, c_idx]
+    p_b_local = contact_point1[world_idx, c_idx]
+    t_a = contact_thickness0[world_idx, c_idx]
+    t_b = contact_thickness1[world_idx, c_idx]
+
+    pose_a = wp.transform_identity()
+    if body_a >= 0:
+        pose_a = body_pose[world_idx, body_a]
+    pose_b = wp.transform_identity()
+    if body_b >= 0:
+        pose_b = body_pose[world_idx, body_b]
+
+    p_a_world = wp.transform_point(pose_a, p_a_local) - t_a * n
+    p_b_world = wp.transform_point(pose_b, p_b_local) + t_b * n
+
+    depth = wp.dot(n, p_b_world - p_a_world)
+    midpoint = 0.5 * (p_a_world + p_b_world)
+    return depth, midpoint
+
+
+@wp.kernel
+def fps_per_pair_kernel(
+    contact_count: wp.array(dtype=wp.int32, ndim=1),
+    contact_point0: wp.array(dtype=wp.vec3, ndim=2),
+    contact_point1: wp.array(dtype=wp.vec3, ndim=2),
+    contact_normal: wp.array(dtype=wp.vec3, ndim=2),
+    contact_shape0: wp.array(dtype=wp.int32, ndim=2),
+    contact_shape1: wp.array(dtype=wp.int32, ndim=2),
+    contact_thickness0: wp.array(dtype=wp.float32, ndim=2),
+    contact_thickness1: wp.array(dtype=wp.float32, ndim=2),
+    shape_body: wp.array(dtype=wp.int32, ndim=2),
+    body_pose: wp.array(dtype=wp.transform, ndim=2),
+    K: wp.int32,
+    keep_mask: wp.array(dtype=wp.int32, ndim=2),
+):
+    """Per-thread (one per (world, c_idx)). The thread whose c_idx is
+    the smallest in its (b0, b1) pair becomes the "pair leader" and
+    runs the FPS picking serially inside its thread; other threads in
+    the same pair return immediately (their cells of ``keep_mask`` are
+    written by the leader).
+
+    Threads from different pairs touch disjoint ``keep_mask`` cells, so
+    leader-vs-leader races cannot happen. Other-thread cells start at
+    0 (must be zeroed by the caller before launch) and are flipped to
+    1 only by the leader of their pair.
+    """
+    world_idx, c_idx = wp.tid()
+    n_count = contact_count[world_idx]
+    if c_idx >= n_count:
+        return
+
+    s0 = contact_shape0[world_idx, c_idx]
+    s1 = contact_shape1[world_idx, c_idx]
+    if s0 == s1:
+        return
+
+    b0 = _resolve_body(world_idx, s0, shape_body)
+    b1 = _resolve_body(world_idx, s1, shape_body)
+
+    # Am I this pair's leader? Smallest c_idx with this (b0, b1).
+    is_leader = wp.bool(True)
+    for j in range(c_idx):
+        sj0 = contact_shape0[world_idx, j]
+        sj1 = contact_shape1[world_idx, j]
+        if sj0 == sj1:
+            continue
+        bj0 = _resolve_body(world_idx, sj0, shape_body)
+        bj1 = _resolve_body(world_idx, sj1, shape_body)
+        if bj0 == b0 and bj1 == b1:
+            is_leader = wp.bool(False)
+    if not is_leader:
+        return
+
+    # Round 0 — seed: pick the deepest contact in this pair.
+    seed_idx = wp.int32(-1)
+    seed_depth = wp.float32(-1.0e30)
+    for j in range(n_count):
+        sj0 = contact_shape0[world_idx, j]
+        sj1 = contact_shape1[world_idx, j]
+        if sj0 == sj1:
+            continue
+        bj0 = _resolve_body(world_idx, sj0, shape_body)
+        bj1 = _resolve_body(world_idx, sj1, shape_body)
+        if bj0 != b0 or bj1 != b1:
+            continue
+        dj, _mp_unused = _depth_and_midpoint(
+            world_idx, j,
+            contact_point0, contact_point1, contact_normal,
+            contact_thickness0, contact_thickness1,
+            bj0, bj1, body_pose,
+        )
+        # Tie-break by smallest c_idx for determinism.
+        if dj > seed_depth or (dj == seed_depth and j < seed_idx):
+            seed_depth = dj
+            seed_idx = j
+    if seed_idx < 0:
+        return  # no candidates (shouldn't happen since c_idx itself is one)
+
+    keep_mask[world_idx, seed_idx] = 1
+    n_picked = wp.int32(1)
+
+    # Rounds 1..K-1 — farthest-point sampling.
+    for r in range(K - 1):
+        if n_picked >= K:
+            break
+        best_idx = wp.int32(-1)
+        best_min_dist_sq = wp.float32(-1.0)
+        for j in range(n_count):
+            sj0 = contact_shape0[world_idx, j]
+            sj1 = contact_shape1[world_idx, j]
+            if sj0 == sj1:
+                continue
+            bj0 = _resolve_body(world_idx, sj0, shape_body)
+            bj1 = _resolve_body(world_idx, sj1, shape_body)
+            if bj0 != b0 or bj1 != b1:
+                continue
+            if keep_mask[world_idx, j] == 1:
+                continue
+            _depth_unused_j, mp_j = _depth_and_midpoint(
+                world_idx, j,
+                contact_point0, contact_point1, contact_normal,
+                contact_thickness0, contact_thickness1,
+                bj0, bj1, body_pose,
+            )
+            # min-distance over already-picked contacts in this pair.
+            min_dist_sq = wp.float32(1.0e30)
+            for k in range(n_count):
+                if keep_mask[world_idx, k] != 1:
+                    continue
+                sk0 = contact_shape0[world_idx, k]
+                sk1 = contact_shape1[world_idx, k]
+                if sk0 == sk1:
+                    continue
+                bk0 = _resolve_body(world_idx, sk0, shape_body)
+                bk1 = _resolve_body(world_idx, sk1, shape_body)
+                if bk0 != b0 or bk1 != b1:
+                    continue
+                _depth_unused_k, mp_k = _depth_and_midpoint(
+                    world_idx, k,
+                    contact_point0, contact_point1, contact_normal,
+                    contact_thickness0, contact_thickness1,
+                    bk0, bk1, body_pose,
+                )
+                d_sq = wp.length_sq(mp_j - mp_k)
+                if d_sq < min_dist_sq:
+                    min_dist_sq = d_sq
+            # Tie-break by smallest c_idx.
+            if min_dist_sq > best_min_dist_sq or (
+                min_dist_sq == best_min_dist_sq and j < best_idx
+            ):
+                best_min_dist_sq = min_dist_sq
+                best_idx = j
+        if best_idx < 0:
+            break  # ran out of candidates in this pair
+        keep_mask[world_idx, best_idx] = 1
+        n_picked += 1
+
+
+@wp.kernel
+def scatter_by_keep_kernel(
+    keep_mask: wp.array(dtype=wp.int32, ndim=2),
+    contact_count: wp.array(dtype=wp.int32, ndim=1),
+    src_point0: wp.array(dtype=wp.vec3, ndim=2),
+    src_point1: wp.array(dtype=wp.vec3, ndim=2),
+    src_normal: wp.array(dtype=wp.vec3, ndim=2),
+    src_shape0: wp.array(dtype=wp.int32, ndim=2),
+    src_shape1: wp.array(dtype=wp.int32, ndim=2),
+    src_thickness0: wp.array(dtype=wp.float32, ndim=2),
+    src_thickness1: wp.array(dtype=wp.float32, ndim=2),
+    new_count: wp.array(dtype=wp.int32, ndim=1),
+    dst_point0: wp.array(dtype=wp.vec3, ndim=2),
+    dst_point1: wp.array(dtype=wp.vec3, ndim=2),
+    dst_normal: wp.array(dtype=wp.vec3, ndim=2),
+    dst_shape0: wp.array(dtype=wp.int32, ndim=2),
+    dst_shape1: wp.array(dtype=wp.int32, ndim=2),
+    dst_thickness0: wp.array(dtype=wp.float32, ndim=2),
+    dst_thickness1: wp.array(dtype=wp.float32, ndim=2),
+):
+    world_idx, c_idx = wp.tid()
+    if c_idx >= contact_count[world_idx]:
+        return
+    if keep_mask[world_idx, c_idx] != 1:
+        return
+
+    slot = wp.atomic_add(new_count, world_idx, 1)
+    dst_point0[world_idx, slot] = src_point0[world_idx, c_idx]
+    dst_point1[world_idx, slot] = src_point1[world_idx, c_idx]
+    dst_normal[world_idx, slot] = src_normal[world_idx, c_idx]
+    dst_shape0[world_idx, slot] = src_shape0[world_idx, c_idx]
+    dst_shape1[world_idx, slot] = src_shape1[world_idx, c_idx]
+    dst_thickness0[world_idx, slot] = src_thickness0[world_idx, c_idx]
+    dst_thickness1[world_idx, slot] = src_thickness1[world_idx, c_idx]
+
+
+class FPSReducer(ContactReducer):
+    """Greedy farthest-point-sampling per-pair contact reduction."""
+
+    def __init__(
+        self,
+        cfg: ContactReductionConfig,
+        axion_model: "AxionModel",
+        data: "EngineData",
+        dims: "EngineDimensions",
+        device: wp.Device,
+    ):
+        self._K = int(cfg.max_per_pair)
+        self._device = device
+        self._shape_body = axion_model.shape_body
+        # body_pose_prev is the current-step pose during load_data.
+        self._body_pose = data.body_pose_prev
+
+        N_w = dims.num_worlds
+        N_c = dims.contact_count
+
+        with wp.ScopedDevice(device):
+            self._keep_mask = wp.zeros((N_w, N_c), dtype=wp.int32)
+            self._new_count = wp.zeros((N_w,), dtype=wp.int32)
+            self._scratch_point0 = wp.zeros((N_w, N_c), dtype=wp.vec3)
+            self._scratch_point1 = wp.zeros((N_w, N_c), dtype=wp.vec3)
+            self._scratch_normal = wp.zeros((N_w, N_c), dtype=wp.vec3)
+            self._scratch_shape0 = wp.zeros((N_w, N_c), dtype=wp.int32)
+            self._scratch_shape1 = wp.zeros((N_w, N_c), dtype=wp.int32)
+            self._scratch_thickness0 = wp.zeros((N_w, N_c), dtype=wp.float32)
+            self._scratch_thickness1 = wp.zeros((N_w, N_c), dtype=wp.float32)
+
+    def apply(self, contacts: "AxionContacts") -> None:
+        N_w = contacts.num_worlds
+        N_c = contacts.max_contacts
+
+        # FPS kernel reads-AND-writes keep_mask, so it must start zeroed.
+        self._keep_mask.zero_()
+
+        wp.launch(
+            kernel=fps_per_pair_kernel,
+            dim=(N_w, N_c),
+            inputs=[
+                contacts.contact_count,
+                contacts.contact_point0,
+                contacts.contact_point1,
+                contacts.contact_normal,
+                contacts.contact_shape0,
+                contacts.contact_shape1,
+                contacts.contact_thickness0,
+                contacts.contact_thickness1,
+                self._shape_body,
+                self._body_pose,
+                self._K,
+            ],
+            outputs=[self._keep_mask],
+            device=self._device,
+        )
+
+        self._new_count.zero_()
+        wp.launch(
+            kernel=scatter_by_keep_kernel,
+            dim=(N_w, N_c),
+            inputs=[
+                self._keep_mask,
+                contacts.contact_count,
+                contacts.contact_point0,
+                contacts.contact_point1,
+                contacts.contact_normal,
+                contacts.contact_shape0,
+                contacts.contact_shape1,
+                contacts.contact_thickness0,
+                contacts.contact_thickness1,
+            ],
+            outputs=[
+                self._new_count,
+                self._scratch_point0,
+                self._scratch_point1,
+                self._scratch_normal,
+                self._scratch_shape0,
+                self._scratch_shape1,
+                self._scratch_thickness0,
+                self._scratch_thickness1,
+            ],
+            device=self._device,
+        )
+
+        wp.copy(contacts.contact_count, self._new_count)
+        wp.copy(contacts.contact_point0, self._scratch_point0)
+        wp.copy(contacts.contact_point1, self._scratch_point1)
+        wp.copy(contacts.contact_normal, self._scratch_normal)
+        wp.copy(contacts.contact_shape0, self._scratch_shape0)
+        wp.copy(contacts.contact_shape1, self._scratch_shape1)
+        wp.copy(contacts.contact_thickness0, self._scratch_thickness0)
+        wp.copy(contacts.contact_thickness1, self._scratch_thickness1)

--- a/src/axion/collision/top_k.py
+++ b/src/axion/collision/top_k.py
@@ -1,0 +1,293 @@
+"""Top-K-by-depth contact reducer.
+
+For each (body0, body1) pair active in a given simulation step, keeps at
+most K contacts (the K with the largest penetration depth). Implemented
+as a two-kernel pipeline plus eight memcpys back to the canonical
+``AxionContacts`` arrays:
+
+    1. ``rank_within_pair_kernel``  — for each contact, count how many
+       contacts in the same world with the same (b0, b1) pair are
+       deeper. The result ``rank`` is the contact's 0-based rank within
+       its pair (0 = deepest).
+
+    2. ``scatter_top_k_kernel``     — every contact with rank < K
+       atomically reserves a slot in a per-world counter and writes
+       itself to the matching index in seven scratch arrays.
+
+    3. ``wp.copy`` back the seven scratch arrays plus the new
+       ``contact_count`` into the ``AxionContacts`` instance.
+
+Depth is computed on the fly inside both kernels — we are launch- and
+cache-bound for this scene, not compute-bound, so duplicating the
+transform-and-dot work in ranking is cheaper than allocating a separate
+depth scratch buffer + extra launch.
+
+The compaction is necessary because downstream constraint kernels gate
+on ``c_idx >= contact_count[w]``, so survivors must live at the front
+of the array for the gate to drop the rejected ones.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import warp as wp
+
+from .base import ContactReducer
+from .config import ContactReductionConfig
+
+if TYPE_CHECKING:
+    from axion.core.contacts import AxionContacts
+    from axion.core.engine_data import EngineData
+    from axion.core.engine_dims import EngineDimensions
+    from axion.core.model import AxionModel
+
+
+@wp.func
+def _resolve_body(world_idx: int, shape_idx: int,
+                  shape_body: wp.array(dtype=wp.int32, ndim=2)) -> int:
+    if shape_idx < 0:
+        return -1
+    return shape_body[world_idx, shape_idx]
+
+
+@wp.func
+def _contact_depth(
+    world_idx: int,
+    c_idx: int,
+    contact_point0: wp.array(dtype=wp.vec3, ndim=2),
+    contact_point1: wp.array(dtype=wp.vec3, ndim=2),
+    contact_normal: wp.array(dtype=wp.vec3, ndim=2),
+    contact_thickness0: wp.array(dtype=wp.float32, ndim=2),
+    contact_thickness1: wp.array(dtype=wp.float32, ndim=2),
+    body_a: int,
+    body_b: int,
+    body_pose: wp.array(dtype=wp.transform, ndim=2),
+) -> float:
+    """World-space penetration depth (positive = penetrating).
+
+    Mirrors the geometry used by ``contact_constraint_kernel`` but computed
+    here from current body poses. Returns ``dot(n, p_b_world − p_a_world)``
+    after the thickness offsets are applied along the normal.
+    """
+    n = contact_normal[world_idx, c_idx]
+    p_a_local = contact_point0[world_idx, c_idx]
+    p_b_local = contact_point1[world_idx, c_idx]
+    t_a = contact_thickness0[world_idx, c_idx]
+    t_b = contact_thickness1[world_idx, c_idx]
+
+    pose_a = wp.transform_identity()
+    if body_a >= 0:
+        pose_a = body_pose[world_idx, body_a]
+    pose_b = wp.transform_identity()
+    if body_b >= 0:
+        pose_b = body_pose[world_idx, body_b]
+
+    p_a_world = wp.transform_point(pose_a, p_a_local) - t_a * n
+    p_b_world = wp.transform_point(pose_b, p_b_local) + t_b * n
+    return wp.dot(n, p_b_world - p_a_world)
+
+
+@wp.kernel
+def rank_within_pair_kernel(
+    contact_count: wp.array(dtype=wp.int32, ndim=1),
+    contact_point0: wp.array(dtype=wp.vec3, ndim=2),
+    contact_point1: wp.array(dtype=wp.vec3, ndim=2),
+    contact_normal: wp.array(dtype=wp.vec3, ndim=2),
+    contact_shape0: wp.array(dtype=wp.int32, ndim=2),
+    contact_shape1: wp.array(dtype=wp.int32, ndim=2),
+    contact_thickness0: wp.array(dtype=wp.float32, ndim=2),
+    contact_thickness1: wp.array(dtype=wp.float32, ndim=2),
+    shape_body: wp.array(dtype=wp.int32, ndim=2),
+    body_pose: wp.array(dtype=wp.transform, ndim=2),
+    rank: wp.array(dtype=wp.int32, ndim=2),
+):
+    """For each active contact, compute how many contacts in the same
+    (b0, b1) pair are deeper.
+
+    Tie-break by original index so ranks are unique and the policy is
+    deterministic across runs (and identical under graph capture replay).
+    Out-of-range threads (c_idx >= contact_count[w]) write a sentinel
+    rank that is always ≥ K, so they're never selected.
+    """
+    world_idx, c_idx = wp.tid()
+    n_count = contact_count[world_idx]
+    if c_idx >= n_count:
+        rank[world_idx, c_idx] = wp.int32(2147483647)
+        return
+
+    s0 = contact_shape0[world_idx, c_idx]
+    s1 = contact_shape1[world_idx, c_idx]
+    if s0 == s1:
+        # Self-pair sentinel; should already be filtered upstream.
+        rank[world_idx, c_idx] = wp.int32(2147483647)
+        return
+
+    b0 = _resolve_body(world_idx, s0, shape_body)
+    b1 = _resolve_body(world_idx, s1, shape_body)
+
+    my_depth = _contact_depth(
+        world_idx, c_idx,
+        contact_point0, contact_point1, contact_normal,
+        contact_thickness0, contact_thickness1,
+        b0, b1, body_pose,
+    )
+
+    r = wp.int32(0)
+    for j in range(n_count):
+        if j == c_idx:
+            continue
+        sj0 = contact_shape0[world_idx, j]
+        sj1 = contact_shape1[world_idx, j]
+        bj0 = _resolve_body(world_idx, sj0, shape_body)
+        bj1 = _resolve_body(world_idx, sj1, shape_body)
+        if bj0 != b0 or bj1 != b1:
+            continue
+        their_depth = _contact_depth(
+            world_idx, j,
+            contact_point0, contact_point1, contact_normal,
+            contact_thickness0, contact_thickness1,
+            bj0, bj1, body_pose,
+        )
+        if their_depth > my_depth:
+            r += 1
+        elif their_depth == my_depth and j < c_idx:
+            r += 1
+
+    rank[world_idx, c_idx] = r
+
+
+@wp.kernel
+def scatter_top_k_kernel(
+    rank: wp.array(dtype=wp.int32, ndim=2),
+    K: wp.int32,
+    contact_count: wp.array(dtype=wp.int32, ndim=1),
+    # Source contact arrays (read).
+    src_point0: wp.array(dtype=wp.vec3, ndim=2),
+    src_point1: wp.array(dtype=wp.vec3, ndim=2),
+    src_normal: wp.array(dtype=wp.vec3, ndim=2),
+    src_shape0: wp.array(dtype=wp.int32, ndim=2),
+    src_shape1: wp.array(dtype=wp.int32, ndim=2),
+    src_thickness0: wp.array(dtype=wp.float32, ndim=2),
+    src_thickness1: wp.array(dtype=wp.float32, ndim=2),
+    # Per-world atomic counter + scratch destinations (write).
+    new_count: wp.array(dtype=wp.int32, ndim=1),
+    dst_point0: wp.array(dtype=wp.vec3, ndim=2),
+    dst_point1: wp.array(dtype=wp.vec3, ndim=2),
+    dst_normal: wp.array(dtype=wp.vec3, ndim=2),
+    dst_shape0: wp.array(dtype=wp.int32, ndim=2),
+    dst_shape1: wp.array(dtype=wp.int32, ndim=2),
+    dst_thickness0: wp.array(dtype=wp.float32, ndim=2),
+    dst_thickness1: wp.array(dtype=wp.float32, ndim=2),
+):
+    """Survivors (rank < K) atomically reserve a slot in ``new_count[w]``
+    and copy themselves to that slot in the scratch arrays."""
+    world_idx, c_idx = wp.tid()
+    if c_idx >= contact_count[world_idx]:
+        return
+    if rank[world_idx, c_idx] >= K:
+        return
+
+    slot = wp.atomic_add(new_count, world_idx, 1)
+    dst_point0[world_idx, slot] = src_point0[world_idx, c_idx]
+    dst_point1[world_idx, slot] = src_point1[world_idx, c_idx]
+    dst_normal[world_idx, slot] = src_normal[world_idx, c_idx]
+    dst_shape0[world_idx, slot] = src_shape0[world_idx, c_idx]
+    dst_shape1[world_idx, slot] = src_shape1[world_idx, c_idx]
+    dst_thickness0[world_idx, slot] = src_thickness0[world_idx, c_idx]
+    dst_thickness1[world_idx, slot] = src_thickness1[world_idx, c_idx]
+
+
+class TopKReducer(ContactReducer):
+    """Per-pair top-K-by-depth contact reduction."""
+
+    def __init__(
+        self,
+        cfg: ContactReductionConfig,
+        axion_model: "AxionModel",
+        data: "EngineData",
+        dims: "EngineDimensions",
+        device: wp.Device,
+    ):
+        self._K = int(cfg.max_per_pair)
+        self._device = device
+        # Persistent references — body_pose_prev holds the current-step
+        # pose during load_data (when reduction runs), because the engine
+        # copies body_pose itself only AFTER load_data returns.
+        self._shape_body = axion_model.shape_body
+        self._body_pose = data.body_pose_prev
+
+        N_w = dims.num_worlds
+        N_c = dims.contact_count
+
+        with wp.ScopedDevice(device):
+            self._rank = wp.zeros((N_w, N_c), dtype=wp.int32)
+            self._new_count = wp.zeros((N_w,), dtype=wp.int32)
+            self._scratch_point0 = wp.zeros((N_w, N_c), dtype=wp.vec3)
+            self._scratch_point1 = wp.zeros((N_w, N_c), dtype=wp.vec3)
+            self._scratch_normal = wp.zeros((N_w, N_c), dtype=wp.vec3)
+            self._scratch_shape0 = wp.zeros((N_w, N_c), dtype=wp.int32)
+            self._scratch_shape1 = wp.zeros((N_w, N_c), dtype=wp.int32)
+            self._scratch_thickness0 = wp.zeros((N_w, N_c), dtype=wp.float32)
+            self._scratch_thickness1 = wp.zeros((N_w, N_c), dtype=wp.float32)
+
+    def apply(self, contacts: "AxionContacts") -> None:
+        N_w = contacts.num_worlds
+        N_c = contacts.max_contacts
+
+        wp.launch(
+            kernel=rank_within_pair_kernel,
+            dim=(N_w, N_c),
+            inputs=[
+                contacts.contact_count,
+                contacts.contact_point0,
+                contacts.contact_point1,
+                contacts.contact_normal,
+                contacts.contact_shape0,
+                contacts.contact_shape1,
+                contacts.contact_thickness0,
+                contacts.contact_thickness1,
+                self._shape_body,
+                self._body_pose,
+            ],
+            outputs=[self._rank],
+            device=self._device,
+        )
+
+        # Reset survivor counter, then scatter.
+        self._new_count.zero_()
+        wp.launch(
+            kernel=scatter_top_k_kernel,
+            dim=(N_w, N_c),
+            inputs=[
+                self._rank,
+                self._K,
+                contacts.contact_count,
+                contacts.contact_point0,
+                contacts.contact_point1,
+                contacts.contact_normal,
+                contacts.contact_shape0,
+                contacts.contact_shape1,
+                contacts.contact_thickness0,
+                contacts.contact_thickness1,
+            ],
+            outputs=[
+                self._new_count,
+                self._scratch_point0,
+                self._scratch_point1,
+                self._scratch_normal,
+                self._scratch_shape0,
+                self._scratch_shape1,
+                self._scratch_thickness0,
+                self._scratch_thickness1,
+            ],
+            device=self._device,
+        )
+
+        wp.copy(contacts.contact_count, self._new_count)
+        wp.copy(contacts.contact_point0, self._scratch_point0)
+        wp.copy(contacts.contact_point1, self._scratch_point1)
+        wp.copy(contacts.contact_normal, self._scratch_normal)
+        wp.copy(contacts.contact_shape0, self._scratch_shape0)
+        wp.copy(contacts.contact_shape1, self._scratch_shape1)
+        wp.copy(contacts.contact_thickness0, self._scratch_thickness0)
+        wp.copy(contacts.contact_thickness1, self._scratch_thickness1)

--- a/src/axion/core/base_engine.py
+++ b/src/axion/core/base_engine.py
@@ -52,13 +52,27 @@ def _check_newton_residuals_kernel(
 def _update_newton_iter_kernel(
     iter_count: wp.array(dtype=int),
     max_iters: int,
+    min_iter: int,
     keep_running: wp.array(dtype=int),
 ):
     # This kernel is explicitly launched with dim=1
     current_iter = iter_count[0] + 1
     iter_count[0] = current_iter
 
+    # Force NR to keep running until we have cleared the backtracking
+    # warmup window. The friction kernel early-exits at iter 0 because
+    # ``constr_force_prev_iter`` is zeroed at engine.step start, which
+    # makes the iter-0 residual "friction-blind" — it can pass the atol
+    # convergence check without representing a physically-valid state
+    # (zero friction force going into the next step). Holding the loop
+    # until iter_count >= backtrack_min_iter ensures any iterate
+    # backtracking can pick has the friction model fully engaged.
+    # Overrides the residual check above when triggered.
+    if current_iter < min_iter:
+        keep_running[0] = 1
+
     # Force stop if we hit max iterations, overriding any residual checks
+    # AND the min-iter override above.
     if current_iter >= max_iters:
         keep_running[0] = 0
 
@@ -200,13 +214,17 @@ class AxionEngineBase(SolverBase):
             device=self.device,
         )
 
-        # 2. Safely manage iter count with exactly 1 thread (Sets keep_running = 0 if max iters reached)
+        # 2. Safely manage iter count with exactly 1 thread.
+        #    Forces keep_running=1 while iter_count < backtrack_min_iter
+        #    (the friction model's warmup window) and keep_running=0
+        #    once iter_count >= max_newton_iters.
         wp.launch(
             kernel=_update_newton_iter_kernel,
             dim=(1,),
             inputs=[
                 self.data.iter_count,
                 self.config.max_newton_iters,
+                self.config.backtrack_min_iter,
                 self.data.keep_running,
             ],
             device=self.device,

--- a/src/axion/core/base_engine.py
+++ b/src/axion/core/base_engine.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import numpy as np
 import warp as wp
+from axion.collision import build_reducer
 from axion.optim import JacobiPreconditioner
 from axion.optim import PCRSolver
 from axion.optim import SystemLinearData
@@ -148,6 +149,10 @@ class AxionEngineBase(SolverBase):
             device=self.device,
         )
 
+        self.contact_reducer = build_reducer(
+            self.config.contact_reduction, self.dims, self.device
+        )
+
         self.logger = None
         if self.logging_config.enable_hdf5_logging:
             self.logger = SimulationHDF5Logger(
@@ -268,6 +273,11 @@ class AxionEngineBase(SolverBase):
             self.data,
             self.dims,
         )
+
+        # Per-pair contact reduction. NoOpReducer is a Python-side return,
+        # so this adds zero kernel overhead when policy="none" (the
+        # default), preserving CUDA-graph capture behavior bit-for-bit.
+        self.contact_reducer.apply(self.axion_contacts)
 
     def compute_warm_start_forces(self):
         """Compute initial contact forces from the predicted body state.

--- a/src/axion/core/base_engine.py
+++ b/src/axion/core/base_engine.py
@@ -341,6 +341,17 @@ class AxionEngineBase(SolverBase):
             """
             self.data.keep_running.zero_()
 
+            # Sync the friction-lag snapshot at the START of the iter so the
+            # linear system and the residual evaluation within this iter both
+            # see the same `prev_iter`. Previously this copy lived between the
+            # solve and the step, which caused a one-iter mismatch: the linear
+            # system was built using prev_iter from end of iter k-2 (friction
+            # often inactive), while the residual used prev_iter from end of
+            # iter k-1 (friction active). Linesearch could not reduce the
+            # friction residual because the search direction had zero in
+            # friction slots when the linear system thought friction was off.
+            wp.copy(dest=self.data._constr_force_prev_iter, src=self.data._constr_force)
+
             if per_component:
                 prof.record_boundary(0, slot_idx)
             compute_linear_system(
@@ -366,7 +377,6 @@ class AxionEngineBase(SolverBase):
             )
             compute_dbody_qd_from_dbody_lambda(self.axion_model, self.data, self.config, self.dims)
 
-            wp.copy(dest=self.data._constr_force_prev_iter, src=self.data._constr_force)
             if per_component:
                 prof.record_boundary(3, slot_idx)
 

--- a/src/axion/core/base_engine.py
+++ b/src/axion/core/base_engine.py
@@ -150,7 +150,11 @@ class AxionEngineBase(SolverBase):
         )
 
         self.contact_reducer = build_reducer(
-            self.config.contact_reduction, self.dims, self.device
+            self.config.contact_reduction,
+            self.axion_model,
+            self.data,
+            self.dims,
+            self.device,
         )
 
         self.logger = None

--- a/src/axion/core/engine_config.py
+++ b/src/axion/core/engine_config.py
@@ -154,6 +154,13 @@ class AxionEngineConfig(EngineConfig):
     def __post_init__(self):
         """Validate all configuration parameters."""
 
+        # Hydra passes nested overrides as a DictConfig, not as a real
+        # ContactReductionConfig instance. Coerce so downstream code can
+        # always assume a frozen dataclass.
+        coerced = ContactReductionConfig.coerce(self.contact_reduction)
+        if coerced is not self.contact_reduction:
+            object.__setattr__(self, "contact_reduction", coerced)
+
         def _validate_positive_int(value: int, name: str, min_value: int = 1) -> None:
             if value < min_value:
                 raise ValueError(f"{name} must be >= {min_value}, got {value}")

--- a/src/axion/core/engine_config.py
+++ b/src/axion/core/engine_config.py
@@ -1,6 +1,8 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from typing import Optional
+
+from axion.collision import ContactReductionConfig
 
 from .engine_profiler import VALID_MODES as _VALID_PROFILING_MODES
 
@@ -93,6 +95,10 @@ class AxionEngineConfig(EngineConfig):
     linesearch_optimistic_window: float = 0.2
 
     max_contacts_per_world: int = 128
+
+    contact_reduction: ContactReductionConfig = field(
+        default_factory=ContactReductionConfig
+    )
 
     joint_constraint_level: str = "pos"  # pos / vel
     contact_constraint_level: str = "pos"  # pos / vel

--- a/tools/dashboard/index.html
+++ b/tools/dashboard/index.html
@@ -385,7 +385,15 @@ async function selectStep(step) {
 function collectBadSteps() {
   if (!cachedConvergence) return [];
   const rows = [];
-  const { step, nr_iters, final_residual_sq, max_newton_iters } = cachedConvergence;
+  const {
+    step,
+    nr_iters,
+    final_residual_sq,
+    final_residual_sq_last,
+    best_idx,
+    max_newton_iters,
+  } = cachedConvergence;
+  const lastResid = final_residual_sq_last || final_residual_sq;
   for (let i = 0; i < step.length; i++) {
     const r = final_residual_sq[i];
     if (r > ATOL_SQ || nr_iters[i] >= max_newton_iters) {
@@ -393,6 +401,8 @@ function collectBadSteps() {
         step: step[i],
         nr: nr_iters[i],
         res: r,
+        res_last: lastResid[i],
+        best_idx: best_idx ? best_idx[i] : nr_iters[i] - 1,
         hit_max: nr_iters[i] >= max_newton_iters,
       });
     }
@@ -409,22 +419,38 @@ function renderBadSteps() {
     return;
   }
   const total = cachedConvergence.step.length;
-  const head = `<thead><tr><th>step</th><th>NR iters</th><th>final ‖r‖²</th><th></th></tr></thead>`;
+  const head = `<thead><tr>
+    <th>step</th>
+    <th>NR iters</th>
+    <th>‖r‖² (picked)</th>
+    <th>‖r‖² (last)</th>
+    <th>picked iter</th>
+    <th></th>
+  </tr></thead>`;
   const body = rows
     .map((r) => {
       const sel = r.step === currentStep ? " selected" : "";
       const warnNr = r.hit_max ? " warn" : "";
       const warnRes = r.res > ATOL_SQ ? " warn" : "";
+      const lastDiffers = Math.abs(Math.log10(r.res_last) - Math.log10(r.res)) > 0.5;
       return `<tr class="bad-row${sel}" data-step="${r.step}">
         <td>${r.step}</td>
         <td class="${warnNr}">${r.nr}${r.hit_max ? " *" : ""}</td>
         <td class="${warnRes}">${r.res.toExponential(2)}</td>
+        <td class="${lastDiffers ? "muted" : ""}">${r.res_last.toExponential(2)}</td>
+        <td class="muted">${r.best_idx} / ${r.nr - 1}</td>
         <td class="muted">${r.hit_max ? "hit max" : ""}</td>
       </tr>`;
     })
     .join("");
   host.innerHTML = `
-    <div class="note">${rows.length} of ${total} step${total === 1 ? "" : "s"} flagged. * = NR ran to max iters.</div>
+    <div class="note">
+      ${rows.length} of ${total} step${total === 1 ? "" : "s"} flagged
+      (‖r‖² &gt; ${ATOL_SQ.toExponential(0)} or NR hit max).
+      "picked" is the iterate backtracking selected and carried into
+      the next step; "last" is the residual at the final NR iter and
+      is for diagnostics only.
+    </div>
     <table class="bad">${head}<tbody>${body}</tbody></table>
   `;
   host.querySelectorAll("tr.bad-row").forEach((tr) => {
@@ -563,12 +589,23 @@ function renderOverview() {
   if (!cachedConvergence) return;
   const data = cachedConvergence;
 
-  const rows = data.step.map((s, i) => ({
-    step: s,
-    res: Math.max(data.final_residual_sq[i], 1e-30),
-    nr: data.nr_iters[i],
-    hit_max: data.nr_iters[i] >= data.max_newton_iters,
-  }));
+  // final_residual_sq is the post-backtrack picked-iter residual; this
+  // is the canonical "did this step actually converge?" number. The
+  // last-iter residual (final_residual_sq_last) is shown as a tooltip
+  // hint when the two differ noticeably.
+  const finalLast = data.final_residual_sq_last || data.final_residual_sq;
+  const rows = data.step.map((s, i) => {
+    const picked = Math.max(data.final_residual_sq[i], 1e-30);
+    const last = Math.max(finalLast[i], 1e-30);
+    return {
+      step: s,
+      res: picked,
+      res_last: last,
+      best_idx: (data.best_idx ? data.best_idx[i] : data.nr_iters[i] - 1),
+      nr: data.nr_iters[i],
+      hit_max: data.nr_iters[i] >= data.max_newton_iters,
+    };
+  });
 
   const marks = [
     Plot.ruleY([ATOL_SQ], { stroke: MUTED, strokeDasharray: "4,3" }),
@@ -577,15 +614,26 @@ function renderOverview() {
       y: "res",
       fill: "hit_max",
       r: 3,
-      title: (d) => `step ${d.step}\n‖r‖²=${d.res.toExponential(2)}\nNR iters=${d.nr}`,
+      title: (d) =>
+        `step ${d.step}\n` +
+        `picked iter ${d.best_idx} / ${d.nr - 1}\n` +
+        `‖r‖² (picked) = ${d.res.toExponential(2)}\n` +
+        `‖r‖² (last)   = ${d.res_last.toExponential(2)}\n` +
+        `NR iters = ${d.nr}`,
     }),
     Plot.tip(
       rows,
       Plot.pointer({
         x: "step",
         y: "res",
-        channels: { nr: "nr" },
-        format: { x: ".0f", y: ".2e", nr: ".0f" },
+        channels: { nr: "nr", best_idx: "best_idx", res_last: "res_last" },
+        format: {
+          x: ".0f",
+          y: ".2e",
+          nr: ".0f",
+          best_idx: ".0f",
+          res_last: ".2e",
+        },
       }),
     ),
   ];
@@ -617,14 +665,21 @@ async function renderStepDetail(step) {
   const data = await fetchJson(`/api/run/${currentRun}/step/${step}?world=${world}`);
 
   const used = data.nr_iters_used;
-  const conv = data.nr_residual_sq[Math.max(used - 1, 0)];
-  $("step-info").textContent = `· step ${data.step} · world ${data.world} · NR ${used}/${data.max_newton_iters} iters · final ‖r‖²=${conv.toExponential(2)}`;
+  const lastIdx = Math.max(used - 1, 0);
+  const bestIdx = (data.best_idx != null) ? data.best_idx : lastIdx;
+  const lastRes = data.nr_residual_sq[lastIdx];
+  const pickedRes = data.nr_residual_sq[bestIdx];
+  $("step-info").textContent =
+    `· step ${data.step} · world ${data.world} · NR ${used}/${data.max_newton_iters} iters · ` +
+    `picked iter ${bestIdx} (‖r‖²=${pickedRes.toExponential(2)}; last iter = ${lastRes.toExponential(2)})`;
 
-  // NR residual decay
+  // NR residual decay — mark the picked iter with a separate ring.
   const nrRows = data.nr_residual_sq.slice(0, used).map((r, k) => ({
     iter: k,
     res: Math.max(r, 1e-30),
+    picked: k === bestIdx,
   }));
+  const pickedRow = nrRows[bestIdx];
   const nrChart = Plot.plot({
     width: chartWidth("nr-chart"),
     height: 240,
@@ -636,15 +691,27 @@ async function renderStepDetail(step) {
       Plot.ruleY([1e-6], { stroke: MUTED, strokeDasharray: "4,3" }),
       Plot.line(nrRows, { x: "iter", y: "res", stroke: ACCENT, strokeWidth: 1.5 }),
       Plot.dot(nrRows, { x: "iter", y: "res", fill: ACCENT, r: 3 }),
+      // Picked iter highlight: bigger hollow ring in green.
+      pickedRow
+        ? Plot.dot([pickedRow], {
+            x: "iter",
+            y: "res",
+            stroke: OK,
+            strokeWidth: 2,
+            r: 7,
+            fill: "none",
+          })
+        : null,
       Plot.tip(
         nrRows,
         Plot.pointer({
           x: "iter",
           y: "res",
-          format: { x: ".0f", y: ".2e" },
+          channels: { picked: "picked" },
+          format: { x: ".0f", y: ".2e", picked: ".0f" },
         }),
       ),
-    ],
+    ].filter(Boolean),
   });
   $("nr-chart").replaceChildren(nrChart);
 

--- a/tools/dashboard/index.html
+++ b/tools/dashboard/index.html
@@ -1,0 +1,835 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>axion convergence</title>
+<style>
+:root {
+  --bg: #fafafa;
+  --panel: #ffffff;
+  --fg: #1f1f1f;
+  --muted: #6c6c6c;
+  --line: #e5e5e5;
+  --accent: #5b6cff;
+  --warn: #e35a4a;
+  --ok: #22a06b;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  font-size: 13px;
+  line-height: 1.4;
+}
+header {
+  padding: 10px 20px;
+  border-bottom: 1px solid var(--line);
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  background: var(--panel);
+}
+header h1 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+header .controls { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
+header label { color: var(--muted); }
+select, input[type=number] {
+  font: inherit;
+  padding: 3px 6px;
+  border: 1px solid var(--line);
+  background: white;
+  border-radius: 3px;
+}
+input[type=number] { width: 70px; }
+main { padding: 16px 20px; display: grid; gap: 16px; }
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 14px 16px;
+}
+.panel h2 {
+  margin: 0 0 10px 0;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+}
+.kv {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 4px 14px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+}
+.kv dt { color: var(--muted); }
+.kv dd { margin: 0; }
+.note { color: var(--muted); font-size: 12px; margin: 0 0 8px 0; }
+.charts { display: grid; gap: 16px; }
+.chart-host { min-height: 1px; }
+figure { margin: 0; }
+.empty {
+  color: var(--muted);
+  font-style: italic;
+  padding: 20px 0;
+  text-align: center;
+}
+.step-picker {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: 8px;
+  font-family: ui-monospace, monospace;
+}
+.step-picker button {
+  font: inherit;
+  padding: 2px 8px;
+  background: white;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  cursor: pointer;
+}
+.step-picker button:hover { background: #f3f3f8; }
+.step-picker button:disabled { color: #bbb; cursor: not-allowed; }
+.step-picker input { width: 70px; }
+table.bad {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+}
+table.bad th {
+  text-align: left;
+  font-weight: 500;
+  color: var(--muted);
+  border-bottom: 1px solid var(--line);
+  padding: 4px 8px;
+  text-transform: uppercase;
+  font-size: 11px;
+  letter-spacing: 0.04em;
+}
+table.bad td {
+  padding: 3px 8px;
+  border-bottom: 1px solid #f0f0f0;
+  cursor: pointer;
+}
+table.bad tr:hover td { background: #f5f7ff; }
+table.bad tr.selected td { background: #e3e9ff; }
+table.bad td.warn { color: var(--warn); }
+table.bad td.muted { color: var(--muted); }
+.bad-empty { color: var(--muted); font-style: italic; padding: 8px 0; }
+</style>
+</head>
+<body>
+<header>
+  <h1>axion convergence</h1>
+  <div class="controls">
+    <label>run <select id="run"></select></label>
+    <label>world <input id="world" type="number" value="0" min="0"></label>
+    <span id="run-size" class="note"></span>
+  </div>
+</header>
+
+<main>
+  <div class="panel">
+    <h2>metadata</h2>
+    <dl class="kv" id="meta"><dd class="empty">no run loaded</dd></dl>
+  </div>
+
+  <div class="panel">
+    <h2>NR residual heatmap</h2>
+    <p class="note">log<sub>10</sub> ‖r‖² for each (step, NR iter) that ran. red = bad, blue = good. click a cell to inspect that step below.</p>
+    <div class="chart-host" id="heatmap"><div class="empty">…</div></div>
+  </div>
+
+  <div class="panel">
+    <h2>convergence overview</h2>
+    <p class="note">final NR ‖r‖² per simulation step (log y). hover for tooltip, click a point to inspect that step below.</p>
+    <div class="chart-host" id="overview"><div class="empty">…</div></div>
+  </div>
+
+  <div class="panel">
+    <h2>residual decomposition (per step, final NR iter)</h2>
+    <p class="note">stacked ‖r‖² split into solver blocks. tells you which physics is failing on bad steps.</p>
+    <div class="chart-host" id="decomp"></div>
+  </div>
+
+  <div class="panel">
+    <h2>bad steps</h2>
+    <p class="note">steps with NR final ‖r‖² above tolerance, sorted by severity. click a row to inspect.</p>
+    <div id="bad-steps-list"></div>
+  </div>
+
+  <div class="panel">
+    <h2>step detail
+      <span class="step-picker">
+        <button id="step-prev" type="button" title="previous step">◀</button>
+        <input id="step-input" type="number" min="0" value="0">
+        <button id="step-next" type="button" title="next step">▶</button>
+      </span>
+      <span id="step-info" class="note"></span>
+    </h2>
+    <div class="charts">
+      <div class="chart-host" id="nr-chart"></div>
+      <div class="chart-host" id="decomp-step-chart"></div>
+      <div class="chart-host" id="pcr-chart"></div>
+      <div class="chart-host" id="alpha-chart"></div>
+    </div>
+  </div>
+</main>
+
+<script type="module">
+import * as Plot from "https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6/+esm";
+
+const $ = (id) => document.getElementById(id);
+const runSel = $("run");
+const worldEl = $("world");
+const runSize = $("run-size");
+const stepInput = $("step-input");
+const stepPrev = $("step-prev");
+const stepNext = $("step-next");
+
+const ACCENT = "#5b6cff";
+const WARN = "#e35a4a";
+const OK = "#22a06b";
+const MUTED = "#888888";
+const SELECTION = "#222";
+
+const ATOL_SQ = 1e-6;  // newton_atol² used for "bad step" classification
+const BAD_STEPS_LIMIT = 100;
+
+let currentRun = null;
+let currentMeta = null;
+let currentStep = null;
+
+// Cached fetched data — refilled on run/world change.
+let cachedHeatmap = null;
+let cachedConvergence = null;
+let cachedDecomp = null;
+
+// ---- data plumbing ----------------------------------------------------------
+
+async function fetchJson(url) {
+  const r = await fetch(url);
+  if (!r.ok) {
+    const t = await r.text();
+    throw new Error(`${r.status} ${t}`);
+  }
+  return r.json();
+}
+
+async function loadRunList() {
+  const runs = await fetchJson("/api/runs");
+  if (!runs.length) {
+    runSel.innerHTML = `<option value="">(no .h5 in data/logs)</option>`;
+    return;
+  }
+  runSel.innerHTML = runs
+    .map((r) => `<option value="${r.name}" data-size="${r.size_mb}">${r.name}</option>`)
+    .join("");
+
+  // Honor URL hash on first load.
+  const h = readHash();
+  if (h.run && Array.from(runSel.options).some((o) => o.value === h.run)) {
+    runSel.value = h.run;
+  }
+  if (h.world != null) worldEl.value = String(h.world);
+
+  await loadRun(h.step != null ? parseInt(h.step, 10) : null);
+}
+
+async function loadRun(initialStep = null) {
+  currentRun = runSel.value;
+  if (!currentRun) return;
+  const opt = runSel.options[runSel.selectedIndex];
+  runSize.textContent = opt.dataset.size ? `(${opt.dataset.size} MB)` : "";
+
+  try {
+    currentMeta = await fetchJson(`/api/run/${currentRun}/meta`);
+    renderMeta(currentMeta);
+  } catch (e) {
+    $("meta").innerHTML = `<dd class="empty">error: ${e.message}</dd>`;
+    return;
+  }
+
+  worldEl.max = (currentMeta.num_worlds ?? 1) - 1;
+  if (parseInt(worldEl.value, 10) > worldEl.max) worldEl.value = 0;
+
+  await fetchOverviewData();
+  renderHeatmap();
+  renderOverview();
+  renderDecomposition();
+  renderBadSteps();
+
+  const numSteps = currentMeta.num_steps ?? 0;
+  stepInput.max = Math.max(0, numSteps - 1);
+
+  // Pick a starting step: URL hash override, else first bad step, else 0.
+  let target = null;
+  if (initialStep != null && initialStep >= 0 && initialStep < numSteps) {
+    target = initialStep;
+  } else if (cachedConvergence) {
+    const bad = collectBadSteps();
+    target = bad.length ? bad[0].step : 0;
+  } else {
+    target = 0;
+  }
+  await selectStep(target);
+}
+
+async function fetchOverviewData() {
+  const world = parseInt(worldEl.value, 10) || 0;
+  const [hm, conv, decomp] = await Promise.all([
+    fetchJson(`/api/run/${currentRun}/heatmap?world=${world}`),
+    fetchJson(`/api/run/${currentRun}/convergence?world=${world}`),
+    fetchJson(`/api/run/${currentRun}/decomposition?world=${world}`),
+  ]);
+  cachedHeatmap = hm;
+  cachedConvergence = conv;
+  cachedDecomp = decomp;
+}
+
+function renderMeta(meta) {
+  const order = ["num_steps", "num_worlds", "max_newton_iters", "max_linear_iters_p1",
+                 "body_count", "dt", "has_pcr_history", "has_linesearch"];
+  const seen = new Set();
+  let html = "";
+  for (const k of order) {
+    if (k in meta) {
+      seen.add(k);
+      html += `<dt>${k}</dt><dd>${formatVal(meta[k])}</dd>`;
+    }
+  }
+  for (const [k, v] of Object.entries(meta)) {
+    if (!seen.has(k)) html += `<dt>${k}</dt><dd>${formatVal(v)}</dd>`;
+  }
+  $("meta").innerHTML = html || `<dd class="empty">empty</dd>`;
+}
+
+function formatVal(v) {
+  if (typeof v === "boolean") return v ? "yes" : "no";
+  if (typeof v === "number" && !Number.isInteger(v)) return v.toExponential(3);
+  return String(v);
+}
+
+// ---- charts -----------------------------------------------------------------
+
+function chartWidth(hostId) {
+  return Math.max(400, $(hostId).clientWidth || 700);
+}
+
+// Block colors for residual decomposition (consistent across charts).
+const BLOCK_COLORS = {
+  dynamics: "#5b6cff",
+  joint: "#22a06b",
+  control: "#a763d4",
+  normal: "#e89c2c",
+  friction: "#e35a4a",
+};
+const BLOCK_ORDER = ["dynamics", "joint", "control", "normal", "friction"];
+
+// ---- URL hash state --------------------------------------------------------
+
+function readHash() {
+  const out = {};
+  const h = location.hash.replace(/^#/, "");
+  if (!h) return out;
+  for (const part of h.split("&")) {
+    const [k, v] = part.split("=");
+    if (k && v != null) out[decodeURIComponent(k)] = decodeURIComponent(v);
+  }
+  return out;
+}
+
+function writeHash() {
+  const parts = [];
+  if (currentRun) parts.push(`run=${encodeURIComponent(currentRun)}`);
+  if (worldEl.value) parts.push(`world=${worldEl.value}`);
+  if (currentStep != null) parts.push(`step=${currentStep}`);
+  history.replaceState(null, "", "#" + parts.join("&"));
+}
+
+// ---- selection -------------------------------------------------------------
+
+async function selectStep(step) {
+  const numSteps = currentMeta?.num_steps ?? 0;
+  if (numSteps <= 0) return;
+  step = Math.max(0, Math.min(numSteps - 1, Math.round(step)));
+  const changed = step !== currentStep;
+  currentStep = step;
+  stepInput.value = String(step);
+  stepPrev.disabled = step <= 0;
+  stepNext.disabled = step >= numSteps - 1;
+  writeHash();
+
+  // Re-render annotations on overview charts (cheap; data is cached).
+  renderHeatmap();
+  renderOverview();
+  renderDecomposition();
+  renderBadSteps();
+
+  if (changed || $("nr-chart").childElementCount === 0) {
+    await renderStepDetail(step);
+  }
+}
+
+// ---- bad steps -------------------------------------------------------------
+
+function collectBadSteps() {
+  if (!cachedConvergence) return [];
+  const rows = [];
+  const { step, nr_iters, final_residual_sq, max_newton_iters } = cachedConvergence;
+  for (let i = 0; i < step.length; i++) {
+    const r = final_residual_sq[i];
+    if (r > ATOL_SQ || nr_iters[i] >= max_newton_iters) {
+      rows.push({
+        step: step[i],
+        nr: nr_iters[i],
+        res: r,
+        hit_max: nr_iters[i] >= max_newton_iters,
+      });
+    }
+  }
+  rows.sort((a, b) => b.res - a.res);
+  return rows.slice(0, BAD_STEPS_LIMIT);
+}
+
+function renderBadSteps() {
+  const rows = collectBadSteps();
+  const host = $("bad-steps-list");
+  if (!rows.length) {
+    host.innerHTML = `<div class="bad-empty">no steps above ‖r‖² = ${ATOL_SQ.toExponential(0)} or hitting max NR iters. nice run.</div>`;
+    return;
+  }
+  const total = cachedConvergence.step.length;
+  const head = `<thead><tr><th>step</th><th>NR iters</th><th>final ‖r‖²</th><th></th></tr></thead>`;
+  const body = rows
+    .map((r) => {
+      const sel = r.step === currentStep ? " selected" : "";
+      const warnNr = r.hit_max ? " warn" : "";
+      const warnRes = r.res > ATOL_SQ ? " warn" : "";
+      return `<tr class="bad-row${sel}" data-step="${r.step}">
+        <td>${r.step}</td>
+        <td class="${warnNr}">${r.nr}${r.hit_max ? " *" : ""}</td>
+        <td class="${warnRes}">${r.res.toExponential(2)}</td>
+        <td class="muted">${r.hit_max ? "hit max" : ""}</td>
+      </tr>`;
+    })
+    .join("");
+  host.innerHTML = `
+    <div class="note">${rows.length} of ${total} step${total === 1 ? "" : "s"} flagged. * = NR ran to max iters.</div>
+    <table class="bad">${head}<tbody>${body}</tbody></table>
+  `;
+  host.querySelectorAll("tr.bad-row").forEach((tr) => {
+    tr.addEventListener("click", () => selectStep(parseInt(tr.dataset.step, 10)));
+  });
+}
+
+// ---- chart rendering (uses cached data) ------------------------------------
+
+function selectionMark() {
+  if (currentStep == null) return null;
+  return Plot.ruleX([currentStep], {
+    stroke: SELECTION,
+    strokeWidth: 1.5,
+    strokeDasharray: "2,2",
+  });
+}
+
+function bindStepClick(chart, dataMaxStep) {
+  const xScale = chart.scale("x");
+  if (!xScale || typeof xScale.apply !== "function") return;
+  chart.style.cursor = "crosshair";
+  chart.addEventListener("click", (ev) => {
+    const rect = chart.getBoundingClientRect();
+    const px = ev.clientX - rect.left;
+    let best = 0,
+      bestDist = Infinity;
+    for (let s = 0; s <= dataMaxStep; s++) {
+      const cx = xScale.apply(s);
+      const d = Math.abs(cx - px);
+      if (d < bestDist) {
+        bestDist = d;
+        best = s;
+      }
+    }
+    selectStep(best);
+  });
+}
+
+function renderHeatmap() {
+  if (!cachedHeatmap) return;
+  const data = cachedHeatmap;
+  const values = data.rows.map((d) => d.log_res);
+  const hi = Math.max(2, Math.ceil(values.length ? Math.max(...values) : 2));
+
+  const marks = [
+    Plot.cell(data.rows, {
+      x: "step",
+      y: "iter",
+      fill: "log_res",
+      inset: 0,
+      title: (d) => `step ${d.step}, iter ${d.iter}\nlog₁₀‖r‖² = ${d.log_res.toFixed(2)}`,
+    }),
+  ];
+  const sel = selectionMark();
+  if (sel) marks.push(sel);
+
+  const chart = Plot.plot({
+    width: chartWidth("heatmap"),
+    height: 28 + (data.max_iter + 1) * 12,
+    marginLeft: 60,
+    marginBottom: 35,
+    style: { fontSize: 11 },
+    x: { label: "step", grid: false },
+    y: { label: "NR iter", reverse: true, grid: false },
+    color: {
+      type: "linear",
+      domain: [-6, hi],
+      range: ["#2b7cd6", "#f7f7f7", "#e35a4a"],
+      legend: true,
+      label: "log₁₀ ‖r‖²",
+    },
+    marks,
+  });
+  bindStepClick(chart, data.max_step);
+  $("heatmap").replaceChildren(chart);
+}
+
+function renderDecomposition() {
+  if (!cachedDecomp) return;
+  const data = cachedDecomp;
+  const eps = 1e-30;
+  const longRows = [];
+  for (const block of BLOCK_ORDER) {
+    if (!(block in data)) continue;
+    for (let i = 0; i < data.step.length; i++) {
+      longRows.push({
+        step: data.step[i],
+        block,
+        value: Math.max(data[block][i], eps),
+      });
+    }
+  }
+
+  const marks = [
+    Plot.line(longRows, {
+      x: "step",
+      y: "value",
+      stroke: "block",
+      strokeWidth: 1.2,
+      curve: "linear",
+    }),
+    Plot.tip(
+      longRows,
+      Plot.pointer({
+        x: "step",
+        y: "value",
+        stroke: "block",
+        format: { x: ".0f", y: ".2e" },
+      }),
+    ),
+  ];
+  const sel = selectionMark();
+  if (sel) marks.push(sel);
+
+  const chart = Plot.plot({
+    width: chartWidth("decomp"),
+    height: 280,
+    marginLeft: 70,
+    marginBottom: 35,
+    style: { fontSize: 11 },
+    x: { label: "step" },
+    y: { type: "log", label: "‖r_block‖² (final iter)", grid: true, tickFormat: ".0e" },
+    color: {
+      domain: BLOCK_ORDER,
+      range: BLOCK_ORDER.map((b) => BLOCK_COLORS[b]),
+      legend: true,
+    },
+    marks,
+  });
+  bindStepClick(chart, (data.step.length || 1) - 1);
+  $("decomp").replaceChildren(chart);
+}
+
+function renderOverview() {
+  if (!cachedConvergence) return;
+  const data = cachedConvergence;
+
+  const rows = data.step.map((s, i) => ({
+    step: s,
+    res: Math.max(data.final_residual_sq[i], 1e-30),
+    nr: data.nr_iters[i],
+    hit_max: data.nr_iters[i] >= data.max_newton_iters,
+  }));
+
+  const marks = [
+    Plot.ruleY([ATOL_SQ], { stroke: MUTED, strokeDasharray: "4,3" }),
+    Plot.dot(rows, {
+      x: "step",
+      y: "res",
+      fill: "hit_max",
+      r: 3,
+      title: (d) => `step ${d.step}\n‖r‖²=${d.res.toExponential(2)}\nNR iters=${d.nr}`,
+    }),
+    Plot.tip(
+      rows,
+      Plot.pointer({
+        x: "step",
+        y: "res",
+        channels: { nr: "nr" },
+        format: { x: ".0f", y: ".2e", nr: ".0f" },
+      }),
+    ),
+  ];
+  const sel = selectionMark();
+  if (sel) marks.push(sel);
+
+  const chart = Plot.plot({
+    width: chartWidth("overview"),
+    height: 320,
+    marginLeft: 70,
+    marginBottom: 35,
+    style: { fontSize: 11 },
+    x: { label: "step", grid: false },
+    y: { type: "log", label: "final NR ‖r‖²", grid: true, tickFormat: ".0e" },
+    color: {
+      domain: [false, true],
+      range: [ACCENT, WARN],
+      legend: true,
+      label: "hit max NR iters",
+    },
+    marks,
+  });
+  bindStepClick(chart, (data.step.length || 1) - 1);
+  $("overview").replaceChildren(chart);
+}
+
+async function renderStepDetail(step) {
+  const world = parseInt(worldEl.value, 10) || 0;
+  const data = await fetchJson(`/api/run/${currentRun}/step/${step}?world=${world}`);
+
+  const used = data.nr_iters_used;
+  const conv = data.nr_residual_sq[Math.max(used - 1, 0)];
+  $("step-info").textContent = `· step ${data.step} · world ${data.world} · NR ${used}/${data.max_newton_iters} iters · final ‖r‖²=${conv.toExponential(2)}`;
+
+  // NR residual decay
+  const nrRows = data.nr_residual_sq.slice(0, used).map((r, k) => ({
+    iter: k,
+    res: Math.max(r, 1e-30),
+  }));
+  const nrChart = Plot.plot({
+    width: chartWidth("nr-chart"),
+    height: 240,
+    marginLeft: 70,
+    style: { fontSize: 11 },
+    x: { label: "NR iteration", grid: false },
+    y: { type: "log", label: "NR ‖r‖²", grid: true, tickFormat: ".0e" },
+    marks: [
+      Plot.ruleY([1e-6], { stroke: MUTED, strokeDasharray: "4,3" }),
+      Plot.line(nrRows, { x: "iter", y: "res", stroke: ACCENT, strokeWidth: 1.5 }),
+      Plot.dot(nrRows, { x: "iter", y: "res", fill: ACCENT, r: 3 }),
+      Plot.tip(
+        nrRows,
+        Plot.pointer({
+          x: "iter",
+          y: "res",
+          format: { x: ".0f", y: ".2e" },
+        }),
+      ),
+    ],
+  });
+  $("nr-chart").replaceChildren(nrChart);
+
+  // Per-NR-iter decomposition for the selected step
+  if (data.decomposition) {
+    const eps = 1e-30;
+    const decompRows = [];
+    for (const block of BLOCK_ORDER) {
+      if (!(block in data.decomposition)) continue;
+      const arr = data.decomposition[block];
+      for (let k = 0; k < used; k++) {
+        decompRows.push({ iter: k, block, value: Math.max(arr[k], eps) });
+      }
+    }
+    const decompChart = Plot.plot({
+      width: chartWidth("decomp-step-chart"),
+      height: 220,
+      marginLeft: 70,
+      style: { fontSize: 11 },
+      x: { label: "NR iteration" },
+      y: { type: "log", label: "‖r_block‖²", grid: true, tickFormat: ".0e" },
+      color: {
+        domain: BLOCK_ORDER,
+        range: BLOCK_ORDER.map((b) => BLOCK_COLORS[b]),
+        legend: true,
+      },
+      marks: [
+        Plot.line(decompRows, {
+          x: "iter",
+          y: "value",
+          stroke: "block",
+          strokeWidth: 1.4,
+        }),
+        Plot.dot(decompRows, {
+          x: "iter",
+          y: "value",
+          fill: "block",
+          r: 2.5,
+        }),
+        Plot.tip(
+          decompRows,
+          Plot.pointer({
+            x: "iter",
+            y: "value",
+            stroke: "block",
+            format: { x: ".0f", y: ".2e" },
+          }),
+        ),
+      ],
+    });
+    $("decomp-step-chart").replaceChildren(decompChart);
+  } else {
+    $("decomp-step-chart").innerHTML = "";
+  }
+
+  // PCR iters per NR iter
+  if (data.pcr_iters_per_nr) {
+    const pcrMax = data.max_linear_iters_p1
+      ? data.max_linear_iters_p1 - 1
+      : (currentMeta.max_linear_iters_p1 ? currentMeta.max_linear_iters_p1 - 1 : null);
+    const pcrRows = data.pcr_iters_per_nr
+      .slice(0, used)
+      .map((c, k) => ({ iter: k, count: c, hit_max: pcrMax != null && c >= pcrMax }));
+    const pcrChart = Plot.plot({
+      width: chartWidth("pcr-chart"),
+      height: 200,
+      marginLeft: 70,
+      style: { fontSize: 11 },
+      x: { label: "NR iteration" },
+      y: { label: "PCR iters", grid: true },
+      color: { domain: [false, true], range: [ACCENT, WARN], legend: false },
+      marks: [
+        pcrMax != null
+          ? Plot.ruleY([pcrMax], { stroke: WARN, strokeDasharray: "4,3" })
+          : null,
+        Plot.barY(pcrRows, { x: "iter", y: "count", fill: "hit_max" }),
+        Plot.tip(
+          pcrRows,
+          Plot.pointer({
+            x: "iter",
+            y: "count",
+            format: { x: ".0f", y: ".0f" },
+          }),
+        ),
+      ].filter(Boolean),
+    });
+    $("pcr-chart").replaceChildren(pcrChart);
+  } else {
+    $("pcr-chart").innerHTML = "";
+  }
+
+  // Chosen α (linesearch)
+  if (data.chosen_alpha) {
+    const aRows = data.chosen_alpha
+      .slice(0, used)
+      .map((a, k) => ({ iter: k, alpha: Math.max(a, 1e-30) }));
+    const aChart = Plot.plot({
+      width: chartWidth("alpha-chart"),
+      height: 200,
+      marginLeft: 70,
+      style: { fontSize: 11 },
+      x: { label: "NR iteration" },
+      y: {
+        type: "log",
+        label: "chosen α",
+        domain: [1e-6, 2],
+        grid: true,
+        tickFormat: ".0e",
+      },
+      marks: [
+        Plot.ruleY([1.0], { stroke: MUTED, strokeDasharray: "4,3" }),
+        Plot.line(aRows, { x: "iter", y: "alpha", stroke: OK, strokeWidth: 1.5 }),
+        Plot.dot(aRows, { x: "iter", y: "alpha", fill: OK, r: 3 }),
+        Plot.tip(
+          aRows,
+          Plot.pointer({
+            x: "iter",
+            y: "alpha",
+            format: { x: ".0f", y: ".2e" },
+          }),
+        ),
+      ],
+    });
+    $("alpha-chart").replaceChildren(aChart);
+  } else {
+    $("alpha-chart").innerHTML = "";
+  }
+}
+
+// ---- wiring ----------------------------------------------------------------
+
+runSel.addEventListener("change", () => loadRun(currentStep));
+worldEl.addEventListener("change", async () => {
+  if (!currentRun) return;
+  await fetchOverviewData();
+  renderHeatmap();
+  renderOverview();
+  renderDecomposition();
+  renderBadSteps();
+  if (currentStep != null) renderStepDetail(currentStep);
+  writeHash();
+});
+
+// Step picker controls.
+stepInput.addEventListener("change", () => {
+  const v = parseInt(stepInput.value, 10);
+  if (!Number.isNaN(v)) selectStep(v);
+});
+stepPrev.addEventListener("click", () => {
+  if (currentStep != null) selectStep(currentStep - 1);
+});
+stepNext.addEventListener("click", () => {
+  if (currentStep != null) selectStep(currentStep + 1);
+});
+window.addEventListener("keydown", (ev) => {
+  if (ev.target.tagName === "INPUT" || ev.target.tagName === "SELECT") return;
+  if (currentStep == null) return;
+  if (ev.key === "ArrowLeft") selectStep(currentStep - 1);
+  else if (ev.key === "ArrowRight") selectStep(currentStep + 1);
+});
+
+// Browser-driven hash changes (e.g., user pastes a URL).
+window.addEventListener("hashchange", () => {
+  const h = readHash();
+  if (h.run && runSel.value !== h.run) {
+    runSel.value = h.run;
+    loadRun(h.step != null ? parseInt(h.step, 10) : null);
+  } else if (h.step != null) {
+    selectStep(parseInt(h.step, 10));
+  }
+});
+
+// rerender on resize so charts adapt
+let resizeTimer;
+window.addEventListener("resize", () => {
+  clearTimeout(resizeTimer);
+  resizeTimer = setTimeout(() => {
+    if (!currentRun) return;
+    renderHeatmap();
+    renderOverview();
+    renderDecomposition();
+  }, 200);
+});
+
+loadRunList();
+</script>
+</body>
+</html>

--- a/tools/dashboard/server.py
+++ b/tools/dashboard/server.py
@@ -1,0 +1,255 @@
+"""Tiny FastAPI server that exposes axion HDF5 logs as JSON for the
+Observable Plot frontend.
+
+Install:
+    uv pip install fastapi uvicorn
+
+Run from repo root:
+    uvicorn tools.dashboard.server:app --reload --port 8000
+
+Then open http://localhost:8000
+"""
+from pathlib import Path
+
+import h5py
+import numpy as np
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse
+
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+LOGS_DIR = ROOT / "data" / "logs"
+HERE = Path(__file__).resolve().parent
+
+app = FastAPI(title="axion convergence")
+
+
+def _to_jsonable(x):
+    if isinstance(x, np.integer):
+        return int(x)
+    if isinstance(x, np.floating):
+        return float(x)
+    if isinstance(x, np.ndarray):
+        return x.tolist()
+    return x
+
+
+def _safe_path(filename: str) -> Path:
+    if "/" in filename or ".." in filename:
+        raise HTTPException(400, "invalid filename")
+    p = LOGS_DIR / filename
+    if not p.is_file():
+        raise HTTPException(404, f"file not found: {filename}")
+    return p
+
+
+@app.get("/")
+def index():
+    return FileResponse(HERE / "index.html")
+
+
+@app.get("/api/runs")
+def list_runs():
+    if not LOGS_DIR.is_dir():
+        return []
+    runs = []
+    for p in LOGS_DIR.glob("*.h5"):
+        runs.append({"name": p.name, "size_mb": round(p.stat().st_size / 1e6, 1)})
+    runs.sort(key=lambda r: r["name"], reverse=True)
+    return runs
+
+
+@app.get("/api/run/{filename}/meta")
+def meta(filename: str):
+    p = _safe_path(filename)
+    with h5py.File(p, "r") as f:
+        out = {k: _to_jsonable(v) for k, v in f.attrs.items()}
+        out["has_pcr_history"] = "pcr_history_res_norm_sq_history" in f
+        out["has_linesearch"] = "ls_history_minimal_index" in f
+        if "iter_count" in f:
+            out["num_steps"] = int(f["iter_count"].shape[0])
+        if "candidates_res_norm_sq" in f:
+            out["max_newton_iters"] = int(f["candidates_res_norm_sq"].shape[1])
+            out["num_worlds"] = int(f["candidates_res_norm_sq"].shape[2])
+        if "pcr_history_res_norm_sq_history" in f:
+            out["max_linear_iters_p1"] = int(
+                f["pcr_history_res_norm_sq_history"].shape[2]
+            )
+        if "body_pose" in f:
+            out["body_count"] = int(f["body_pose"].shape[2])
+        return out
+
+
+@app.get("/api/run/{filename}/convergence")
+def convergence(filename: str, world: int = 0):
+    """Per-step summary: NR iters used and final NR ‖r‖²."""
+    p = _safe_path(filename)
+    with h5py.File(p, "r") as f:
+        if "iter_count" not in f or "candidates_res_norm_sq" not in f:
+            raise HTTPException(400, "file missing iter_count/candidates_res_norm_sq")
+        nr_iters = f["iter_count"][:, 0].astype(int)
+        cand = f["candidates_res_norm_sq"]
+        S, K, W = cand.shape
+        if world < 0 or world >= W:
+            raise HTTPException(400, f"world out of range (0..{W-1})")
+        nr_res = cand[:, :, world]
+        last_idx = np.maximum(nr_iters - 1, 0)
+        final = nr_res[np.arange(S), last_idx]
+        max_K = K
+        return {
+            "step": list(range(S)),
+            "nr_iters": nr_iters.tolist(),
+            "final_residual_sq": [float(x) for x in final],
+            "max_newton_iters": max_K,
+        }
+
+
+@app.get("/api/run/{filename}/heatmap")
+def heatmap(filename: str, world: int = 0):
+    """Per-(step, NR-iter) NR ‖r‖² for a heatmap.
+
+    Returns flattened rows {step, iter, log_res, ran}. Iters that did not
+    actually execute (k >= iter_count[step]) are marked ran=False so the
+    frontend can blank them.
+    """
+    p = _safe_path(filename)
+    with h5py.File(p, "r") as f:
+        if "iter_count" not in f or "candidates_res_norm_sq" not in f:
+            raise HTTPException(400, "file missing iter_count/candidates_res_norm_sq")
+        nr_iters = f["iter_count"][:, 0].astype(int)
+        cand = f["candidates_res_norm_sq"][:, :, world]
+        S, K = cand.shape
+        ran = (np.arange(K)[None, :] < nr_iters[:, None]).astype(bool)
+        log_res = np.log10(np.maximum(cand, 1e-30))
+        rows = []
+        for s in range(S):
+            for k in range(K):
+                if ran[s, k]:
+                    rows.append({"step": int(s), "iter": int(k),
+                                 "log_res": float(log_res[s, k])})
+        return {
+            "rows": rows,
+            "max_step": int(S - 1),
+            "max_iter": int(K - 1),
+        }
+
+
+def _residual_offsets(f: h5py.File):
+    """Return slice ranges for each block of the residual vector.
+
+    Standard layout in `_res` (and `_candidates_res`):
+        [0, N_u)           dynamics  (6 floats per body)
+        [N_u, N_u+N_j)     joint
+        [+N_ctrl)          control
+        [+N_n)             contact normal
+        [+N_f)             contact friction
+    """
+    if "dims" not in f:
+        raise HTTPException(400, "file missing 'dims' group with offset attrs")
+    d = f["dims"].attrs
+    N_u, N_j, N_ctrl, N_n, N_f = (
+        int(d["N_u"]), int(d["N_j"]), int(d["N_ctrl"]),
+        int(d["N_n"]), int(d["N_f"]),
+    )
+    o0 = 0
+    o1 = N_u
+    o2 = o1 + N_j
+    o3 = o2 + N_ctrl
+    o4 = o3 + N_n
+    o5 = o4 + N_f
+    return [
+        ("dynamics", o0, o1),
+        ("joint",    o1, o2),
+        ("control",  o2, o3),
+        ("normal",   o3, o4),
+        ("friction", o4, o5),
+    ]
+
+
+def _block_sq_norms(arr_2d: np.ndarray, blocks):
+    """arr_2d: (..., N_total). Returns dict name -> (...,) of ‖block‖²."""
+    out = {}
+    for name, lo, hi in blocks:
+        out[name] = np.sum(arr_2d[..., lo:hi] ** 2, axis=-1)
+    return out
+
+
+@app.get("/api/run/{filename}/decomposition")
+def decomposition(filename: str, world: int = 0):
+    """Per-step residual decomposition at the FINAL NR iter of each step.
+
+    Returns step + per-block ‖r‖² so the frontend can stack them.
+    """
+    p = _safe_path(filename)
+    with h5py.File(p, "r") as f:
+        if "_candidates_res" not in f or "iter_count" not in f:
+            raise HTTPException(400, "file missing _candidates_res / iter_count")
+        cand_res = f["_candidates_res"]                  # (S, K, W, N)
+        nr_iters = f["iter_count"][:, 0].astype(int)
+        S, K, W, N = cand_res.shape
+        last_idx = np.maximum(nr_iters - 1, 0)
+        # Read just the per-step final-iter slice. h5py allows indexing
+        # along axis 0 with arrays via fancy access, but it's simpler to
+        # do a loop here since S = 200 typical.
+        final_per_step = np.empty((S, N), dtype=np.float64)
+        for s in range(S):
+            final_per_step[s] = cand_res[s, last_idx[s], world]
+        blocks = _residual_offsets(f)
+        norms = _block_sq_norms(final_per_step, blocks)
+        out = {"step": list(range(S))}
+        for name, _, _ in blocks:
+            out[name] = [float(x) for x in norms[name]]
+        return out
+
+
+@app.get("/api/run/{filename}/step/{step}")
+def step_detail(filename: str, step: int, world: int = 0):
+    """Per-NR-iter detail for a chosen step."""
+    p = _safe_path(filename)
+    with h5py.File(p, "r") as f:
+        if "iter_count" not in f:
+            raise HTTPException(400, "file missing iter_count")
+        S = int(f["iter_count"].shape[0])
+        if step < 0 or step >= S:
+            raise HTTPException(400, f"step out of range (0..{S-1})")
+        max_K = int(f["candidates_res_norm_sq"].shape[1])
+        nr_iters_used = int(f["iter_count"][step, 0])
+
+        out = {
+            "step": step,
+            "world": world,
+            "nr_iters_used": nr_iters_used,
+            "max_newton_iters": max_K,
+            "nr_residual_sq": f["candidates_res_norm_sq"][step, :, world]
+            .astype(float)
+            .tolist(),
+        }
+
+        if "pcr_history_iter_count" in f:
+            out["pcr_iters_per_nr"] = (
+                f["pcr_history_iter_count"][step, :, 0].astype(int).tolist()
+            )
+
+        if "pcr_history_res_norm_sq_history" in f:
+            pcr = f["pcr_history_res_norm_sq_history"][step, :, :, world]
+            out["pcr_residual_history"] = pcr.astype(float).tolist()
+
+        if "ls_history_minimal_index" in f and "ls_history_step_size" in f:
+            ls_idx = f["ls_history_minimal_index"][step, :, world].astype(int)
+            ls_grid = f["ls_history_step_size"][step]  # (K, A)
+            chosen = []
+            for k in range(max_K):
+                row = ls_grid[k] if ls_grid.ndim == 2 else ls_grid
+                chosen.append(float(row[ls_idx[k]]))
+            out["chosen_alpha"] = chosen
+
+        if "_candidates_res" in f and "dims" in f:
+            blocks = _residual_offsets(f)
+            cand_res = f["_candidates_res"][step, :, world, :]  # (K, N)
+            norms = _block_sq_norms(cand_res, blocks)
+            out["decomposition"] = {
+                name: [float(x) for x in norms[name]]
+                for name, _, _ in blocks
+            }
+
+        return out

--- a/tools/dashboard/server.py
+++ b/tools/dashboard/server.py
@@ -80,9 +80,28 @@ def meta(filename: str):
         return out
 
 
+def _best_indices(f: h5py.File, nr_iters: np.ndarray, world: int) -> np.ndarray:
+    """Per-step picked NR iter (the one backtracking selected — the
+    iterate whose residual is actually carried into the next step).
+
+    Falls back to ``iter_count - 1`` (the literal last iter) if the
+    file predates the backtracking-history field, and clamps to
+    ``[0, iter_count − 1]`` regardless.
+    """
+    S = nr_iters.shape[0]
+    if "candidates_best_idx" in f:
+        best = f["candidates_best_idx"][:, world].astype(int)
+    else:
+        best = np.maximum(nr_iters - 1, 0)
+    upper = np.maximum(nr_iters - 1, 0)
+    return np.clip(best, 0, upper)
+
+
 @app.get("/api/run/{filename}/convergence")
 def convergence(filename: str, world: int = 0):
-    """Per-step summary: NR iters used and final NR ‖r‖²."""
+    """Per-step summary: NR iters used and the final ‖r‖² at the
+    iterate that backtracking actually picked (NOT the residual at
+    the last NR iter — those can differ substantially)."""
     p = _safe_path(filename)
     with h5py.File(p, "r") as f:
         if "iter_count" not in f or "candidates_res_norm_sq" not in f:
@@ -93,14 +112,23 @@ def convergence(filename: str, world: int = 0):
         if world < 0 or world >= W:
             raise HTTPException(400, f"world out of range (0..{W-1})")
         nr_res = cand[:, :, world]
+        best_idx = _best_indices(f, nr_iters, world)
         last_idx = np.maximum(nr_iters - 1, 0)
-        final = nr_res[np.arange(S), last_idx]
-        max_K = K
+        final_picked = nr_res[np.arange(S), best_idx]
+        final_last = nr_res[np.arange(S), last_idx]
         return {
             "step": list(range(S)),
             "nr_iters": nr_iters.tolist(),
-            "final_residual_sq": [float(x) for x in final],
-            "max_newton_iters": max_K,
+            # final_residual_sq is the residual AT the iterate that's
+            # actually carried forward (post-backtrack). Frontend treats
+            # this as the canonical "final" for bad-step classification.
+            "final_residual_sq": [float(x) for x in final_picked],
+            # final_residual_sq_last is the residual at the literal last
+            # NR iter, kept for diagnostics — useful for spotting cases
+            # where the last iter was much worse than the picked one.
+            "final_residual_sq_last": [float(x) for x in final_last],
+            "best_idx": best_idx.tolist(),
+            "max_newton_iters": K,
         }
 
 
@@ -176,7 +204,8 @@ def _block_sq_norms(arr_2d: np.ndarray, blocks):
 
 @app.get("/api/run/{filename}/decomposition")
 def decomposition(filename: str, world: int = 0):
-    """Per-step residual decomposition at the FINAL NR iter of each step.
+    """Per-step residual decomposition at the iterate backtracking
+    picked (not the literal last NR iter).
 
     Returns step + per-block ‖r‖² so the frontend can stack them.
     """
@@ -187,13 +216,13 @@ def decomposition(filename: str, world: int = 0):
         cand_res = f["_candidates_res"]                  # (S, K, W, N)
         nr_iters = f["iter_count"][:, 0].astype(int)
         S, K, W, N = cand_res.shape
-        last_idx = np.maximum(nr_iters - 1, 0)
-        # Read just the per-step final-iter slice. h5py allows indexing
+        best_idx = _best_indices(f, nr_iters, world)
+        # Read just the per-step picked-iter slice. h5py allows indexing
         # along axis 0 with arrays via fancy access, but it's simpler to
         # do a loop here since S = 200 typical.
         final_per_step = np.empty((S, N), dtype=np.float64)
         for s in range(S):
-            final_per_step[s] = cand_res[s, last_idx[s], world]
+            final_per_step[s] = cand_res[s, best_idx[s], world]
         blocks = _residual_offsets(f)
         norms = _block_sq_norms(final_per_step, blocks)
         out = {"step": list(range(S))}
@@ -215,11 +244,18 @@ def step_detail(filename: str, step: int, world: int = 0):
         max_K = int(f["candidates_res_norm_sq"].shape[1])
         nr_iters_used = int(f["iter_count"][step, 0])
 
+        if "candidates_best_idx" in f:
+            best_idx = int(f["candidates_best_idx"][step, world])
+            best_idx = max(0, min(best_idx, max(nr_iters_used - 1, 0)))
+        else:
+            best_idx = max(nr_iters_used - 1, 0)
+
         out = {
             "step": step,
             "world": world,
             "nr_iters_used": nr_iters_used,
             "max_newton_iters": max_K,
+            "best_idx": best_idx,
             "nr_residual_sq": f["candidates_res_norm_sq"][step, :, world]
             .astype(float)
             .tolist(),


### PR DESCRIPTION
## Summary

A stack of related work on solver convergence and contact handling, in three groups:

**Engine fixes (correctness)**
- **Friction-lag snapshot timing** (`78cdb41`): move the `wp.copy(prev_iter ← constr_force)` to the start of `nr_loop_step` so the linear system and the residual evaluation within one iter both see the same `prev_iter`. Newton was previously building the linear system without friction at iter 1 while the residual evaluated *with* friction active, which made the search direction unable to reduce the friction term and Newton oscillated. ~21% step-time reduction on the Helhest surface drive (9.68 → 7.68 ms mean), 100% of steps used to hit max NR; now 44%.
- **Don't early-exit before `backtrack_min_iter`** (`5bc4305`): `_check_newton_residuals_kernel` was a pure `‖r‖² < atol²` test with no awareness of `backtrack_min_iter`. If the residual happened to drop below `atol²` at iter < min, NR exited and backtracking carried forward an iter inside the friction warmup window (residual computed without the friction block — silently invalid). Helhest obstacle, no contact reduction: friction-blind picks 31/200 → 0/200, bad steps 6 → 2.

**Contact reduction subsystem** (new `src/axion/collision/`)
- Phase 0 — scaffolding: `ContactReductionConfig` dataclass, `ContactReducer` ABC, `NoOpReducer`, `build_reducer` factory wired into `AxionEngineConfig` and `AxionEngineBase`. Default policy is `none`, so existing scenes are bit-for-bit unchanged.
- Phase 1 — `top_k`: per-(b0,b1) pair, keep the K deepest contacts by world-space penetration depth. Two-kernel pipeline (rank + atomic-counter scatter) plus 8 `wp.copy` back to `AxionContacts`.
- Phase 2 — `fps`: per-pair greedy farthest-point sampling, seeded with the deepest contact, distance metric is contact-midpoint Euclidean.
- Phase 3 — `cluster`: per-pair near-duplicate clustering by normal-dot + midpoint-distance thresholds, keep deepest-per-cluster, top-K-among-representatives.

Picked policy comparison on the obstacle benchmark, K=4 (using picked-iter residual, not last-iter):

```
                    contacts  hit_max_NR  picked ‖r‖² max  bad steps (>1e-3)
none                31/44     71/200      4.8e-2           6
top_k               29/29     77/200      5.3e-1           3
fps                 29/29     57/200      3.6e-2           8
cluster             16/21     47/200      3.1e-3           1
```

Cluster wins on every metric and uses ~half the contacts. Phases 4 (convex-hull) and 5 (multi-scene comparison harness) from the original plan are deferred.

**Tooling**
- Convergence dashboard at `tools/dashboard/` — FastAPI + Observable Plot, single-page UI with residual heatmap, decomposition by solver block, step picker, bad-steps table, URL-hash state. After backtracking-fix (`30f4538`), it reports the picked-iter residual the engine actually carries forward, with last-iter shown alongside for diagnostics.
- Headless deterministic benchmark scenes: `surface_drive_benchmark.py` and `obstacle_benchmark.py` plus per-step PCR-trace `surface_drive_diagnose.py`.

## Test plan

- [ ] `python examples/helhest/surface_drive_benchmark.py` — runs without errors, profiler prints reasonable numbers
- [ ] `python examples/helhest/obstacle_benchmark.py +engine.contact_reduction.policy=cluster +engine.contact_reduction.max_per_pair=4 logging=hdf5` — succeeds, produces a converged HDF5
- [ ] `python examples/helhest/surface_drive_diagnose.py` — produces an NPZ trace and a summary print
- [ ] `uvicorn tools.dashboard.server:app --reload --port 8000` — opens, lists runs, click-through works
- [ ] Existing GL example (e.g. `examples/helhest/obstacle.py`) still runs interactively
- [ ] Default policy (no flag) is `none` — verify a run without `+engine.contact_reduction.*` matches pre-PR output (modulo the two engine fixes which are intended to change behavior)

## What's left for follow-up

- Phase 4 (convex-hull policy) — was estimated at ~3 days and cluster is already a clear winner on the only scene we tested; not blocking the merge.
- Phase 5 (multi-scene comparison harness) — would validate cluster as the default across more scenes. Not blocking; cluster=K is opt-in, no scene's behavior changes without setting it.
- The `linesearch` path is *not* changed in this PR; the friction-lag fix uncovered some related issues there (small-α trapping) but those are separate work.